### PR TITLE
[#14] 공통 셀렉트박스, 모달 컴포넌트 구현

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+제목:
+[해결한 이슈 번호들(,로 구분)] 구현 내용 요약
+
+## 📌 Description
+- 상세 내용 설명
+
+## ⚠️ 주의사항
+- 고민사항, Reviewer가 유의할 점 등
+
+close #issueNumber

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,8 +9,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
       - name: Check lint
@@ -21,15 +33,27 @@ jobs:
         
       - name: Check types
         run: tsc -p tsconfig.json --noEmit
-  
+
   Build-Test:
     runs-on: ubuntu-latest
     needs: [CI-Test]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
         
       - name: Build project

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,164 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+import { createPortal } from 'react-dom';
+import SelectBox from './SelectBox';
+
+const ModalOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(100, 212, 171, 0.1);
+`;
+
+const ModalWrapper = styled.div`
+  padding: 4rem 2.5rem;
+  width: 32rem;
+  height: 18rem;
+  background: rgba(255, 255, 255, 1);
+  border-radius: 8px;
+  box-shadow: 0px 4px 16px 4px rgba(0, 0, 0, 0.2);
+`;
+
+const ModalContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ModalDescription = styled.p`
+  font-size: 1.2rem;
+  text-align: center;
+`;
+
+const ModalButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-evenly;
+`;
+
+const ModalButton = styled.button`
+  width: 8rem;
+  height: 2.5rem;
+  border-radius: 8px;
+  background-color: rgba(100, 212, 171, 1);
+  color: white;
+  line-height: 10%;
+`;
+
+const SelectAdminContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+`;
+
+const SelectAdminText = styled.p`
+  color: #76808e;
+`;
+
+type ModalType = 'normal' | 'exitPlan';
+
+interface Props {
+  type: ModalType;
+  description: string;
+  requestAPI: () => void;
+  onClose: () => void;
+}
+
+interface PortalProps {
+  children: ReactNode;
+}
+
+interface NormalProps {
+  description: string;
+  requestAPI: () => void;
+  onClose: () => void;
+}
+
+interface ExitPlanProps {
+  description: string;
+  members: string[][];
+  requestAPI: () => void;
+  onClose: () => void;
+}
+
+function ModalPortal({ children }: PortalProps) {
+  return <>{createPortal(children, document.body)}</>;
+}
+
+// 일반 모달
+function NormalModal({ description, requestAPI, onClose }: NormalProps) {
+  return (
+    <>
+      <ModalDescription>{description}</ModalDescription>
+      <ModalButtonContainer>
+        <ModalButton type="button" onClick={requestAPI}>
+          예
+        </ModalButton>
+        <ModalButton type="button" onClick={onClose}>
+          아니오
+        </ModalButton>
+      </ModalButtonContainer>
+    </>
+  );
+}
+
+// 관리자가 플랜을 나갈떄 사용할 모달
+function ExitPlanModal({ description, members, requestAPI, onClose }: ExitPlanProps) {
+  const options = members.map((member) => {
+    return { value: member[1], label: member[0] };
+  });
+  return (
+    <>
+      <ModalDescription>{description}</ModalDescription>
+      <SelectAdminContainer>
+        <SelectAdminText>관리자 지정</SelectAdminText>
+        <SelectBox options={options} />
+      </SelectAdminContainer>
+      <ModalButtonContainer>
+        <ModalButton type="button" onClick={requestAPI}>
+          예
+        </ModalButton>
+        <ModalButton type="button" onClick={onClose}>
+          아니오
+        </ModalButton>
+      </ModalButtonContainer>
+    </>
+  );
+}
+
+export default function Modal({ type, description, requestAPI, onClose }: Props) {
+  // 테스트용 더미데이터
+  const testMemebers = [
+    ['신우성', 'sws@gmail.com'],
+    ['김태훈', 'kth@gmail.com'],
+    ['한현', 'hh@gmail.com'],
+  ];
+  return (
+    <ModalPortal>
+      <ModalOverlay>
+        <ModalWrapper>
+          <ModalContainer>
+            {type === 'normal' && <NormalModal description={description} requestAPI={requestAPI} onClose={onClose} />}
+            {type === 'exitPlan' && (
+              <ExitPlanModal
+                description={description}
+                members={testMemebers}
+                requestAPI={requestAPI}
+                onClose={onClose}
+              />
+            )}
+          </ModalContainer>
+        </ModalWrapper>
+      </ModalOverlay>
+    </ModalPortal>
+  );
+}

--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const SelectBoxContainer = styled.div`
+  position: relative;
+  width: 6rem;
+  height: 2rem;
+  display: flex;
+  border-radius: 8px;
+  background-color: #fafafa;
+  align-items: center;
+  justify-content: space-between;
+
+  cursor: pointer;
+`;
+
+const Selected = styled.label`
+  font-size: 14px;
+  margin-left: 4px;
+  width: 4rem;
+  text-align: center;
+`;
+
+const SelectOptions = styled.ul`
+  position: absolute;
+  list-style: none;
+  top: 2rem;
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  padding: 0;
+  border-radius: 8px;
+  background-color: #fafafa;
+`;
+
+const Option = styled.li`
+  font-size: 14px;
+  padding: 6px 8px;
+  text-align: center;
+  transition: background-color 0.2s ease-in;
+  &:hover {
+    background-color: #64d4ab;
+  }
+`;
+
+const SelectBoxArrowContainer = styled.div`
+  width: 25px;
+  height: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const SelectBoxArrow = styled.svg<{ showOptions: boolean }>`
+  transition-duration: 0.3s;
+  transform: rotate(${(props) => (props.showOptions ? '180deg' : 0)});
+`;
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  options: SelectOption[];
+}
+
+export default function SelectBox({ options }: Props) {
+  const [selectedValue, setSelectedValue] = useState<SelectOption>(options[0]);
+  const [showOptions, setShowOptions] = useState<boolean>(false);
+  return (
+    <SelectBoxContainer onClick={() => setShowOptions((prev) => !prev)}>
+      <Selected>{selectedValue.label}</Selected>
+      {showOptions && (
+        <SelectOptions>
+          {options.map((option) => (
+            <Option key={option.value} value={option.value} onClick={() => setSelectedValue(option)}>
+              {option.label}
+            </Option>
+          ))}
+        </SelectOptions>
+      )}
+      <SelectBoxArrowContainer>
+        <SelectBoxArrow
+          showOptions={showOptions}
+          xmlns="http://www.w3.org/2000/svg"
+          width="11"
+          height="6"
+          viewBox="0 0 11 6"
+          fill="none"
+        >
+          <path d="M0.291664 0.416748L5.5 5.62508L10.7083 0.416748H0.291664Z" fill="#8993A1" />
+        </SelectBoxArrow>
+      </SelectBoxArrowContainer>
+    </SelectBoxContainer>
+  );
+}

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+import Modal from '../components/Modal';
+
+export default function useModal() {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const openModal = () => setShowModal(true);
+  const closeModal = () => setShowModal(false);
+  return { Modal, showModal, openModal, closeModal };
+}


### PR DESCRIPTION
## 📌 Description
- Portal을 이용하여 모달을 구현했습니다.
  - Portal을 사용한 이유는 2번째 파라미터를 이용하여 원하는 곳에 렌더링할 수 있고, z-index나 DOM 계층 구조를 변경하지 않고 컴포넌트를 원하는 위치에 배치할 수 있기 때문입니다.
  - 모달은 특히 페이지 위에 표시되는 오버레이이기 때문에 특정 DOM 내부에 위치하는 것보다 body 아래에 바로 붙어야하는 것이 좀더 구조적으로 맞다고 생각한 것도 이유중 하나 입니다.
  - 재사용성을 위해 컴포넌트로 분리하여 구현하였습니다.
- 매번 PR convention을 복사해오는 것이 비효율적이라 생각하여 PR Template을 만들어보았습니다.
- GitHub Actions이 모두 종료되는 시간이 의존성을 설치하는 시간에 의해 너무 길어져 캐싱을 이용하여 개선하였습니다.

## ⚠️ 주의사항
- 모달의 종류가 많아질 경우 어떤식으로 확장하면 좋을지 같이 고민해보면 좋을 것 같습니다.
- Hook을 이용하여 Modal을 보여줄지 관리하였는데 꼭 필요할 것 같진 않아 이것 또한 같이 이야기해보고 싶어요.

close #14 