### PR TITLE
[#23] 플랜 페이지 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import SignUp from './pages/SignUp';
 import Main from './pages/Main';
 import GoogleOauthCallback from './pages/GoogleOauthCallback';
 import CreatePlan from './pages/CreatePlan';
+import Plan from './pages/Plan';
 import GlobalStyle from './styles/GlobalStyle';
 import GlobalFonts from './styles/GlobalFont';
 import Header from './components/Header';
@@ -31,6 +32,10 @@ const router = createBrowserRouter([
       {
         path: '/create-plan',
         element: <CreatePlan />,
+      },
+      {
+        path: '/plan',
+        element: <Plan />,
       },
     ],
   },

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -63,8 +63,8 @@ const NavLink = styled(Link)<{ selected: boolean }>`
 
 // TODO: navMenu link 수정
 const navMenu = [
-  { id: 1, value: 'home', icon: MdHome, link: '/#' },
-  { id: 2, value: 'plan', icon: MdCalendarMonth, link: '/#' },
+  { id: 1, value: 'home', icon: MdHome, link: '/' },
+  { id: 2, value: 'plan', icon: MdCalendarMonth, link: '/plan' },
   { id: 3, value: 'explore', icon: ImCompass2, link: '/#' },
 ];
 

--- a/src/components/LabelFilter.tsx
+++ b/src/components/LabelFilter.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Container = styled.ul`
+  width: 11rem;
+  height: 50%;
+  border-radius: 1rem;
+  padding: 1rem;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffffff;
+`;
+
+export default function LabelFilter() {
+  return (
+    <Container>
+      {/* TODO 라벨 필터링 */}
+      <span>레이블</span>
+    </Container>
+  );
+}

--- a/src/components/MemberFilter.tsx
+++ b/src/components/MemberFilter.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Memberlist = styled.ul`
+  width: fit-content;
+  background-color: #ffffff;
+`;
+
+export default function MemberFilter() {
+  return (
+    <Memberlist>
+      {/* TODO 멤버 필터링 */}
+      member
+    </Memberlist>
+  );
+}

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -65,7 +65,8 @@ function TabHeader({ title, onEdit }: Props) {
 function TasksContainer() {
   return (
     <Container>
-      {/* TODO 할일 리스트 */}
+      {/* TODO 할일 칸반 리스트 */}
+      {/* TODO 할일 drag&drop */}
       <AddButton type="button" className="add">
         {/* TODO 클릭시 일정 추가(모달) */}
         Add Item

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import styled from 'styled-components';
+import { IoIosMore } from 'react-icons/io';
+
+type Props = {
+  title: string;
+  onEdit: () => void;
+};
+
+const Wrapper = styled.li`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const Header = styled.div`
+  padding-inline: 0.8rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .planTitle {
+    font-size: 1.126rem;
+  }
+
+  .icon {
+    cursor: pointer;
+  }
+`;
+
+const Container = styled.div`
+  width: 19rem;
+  height: calc(100% - 2rem);
+  padding: 1rem;
+  border-radius: 1.1rem;
+  background-color: #ffffff;
+  position: relative;
+`;
+
+const AddButton = styled.button`
+  position: absolute;
+  width: 17rem;
+  height: 3rem;
+  border-radius: 0.5rem;
+  background-color: #fafafa;
+  color: #8993a1;
+  font-weight: 600;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+`;
+
+function TabHeader({ title, onEdit }: Props) {
+  return (
+    <Header>
+      <span className="planTitle">{title}</span>
+      <button type="button" className="icon" onClick={onEdit}>
+        <IoIosMore size="24" />
+      </button>
+    </Header>
+  );
+}
+
+function TasksContainer() {
+  return (
+    <Container>
+      {/* TODO 할일 리스트 */}
+      <AddButton type="button" className="add">
+        {/* TODO 클릭시 일정 추가(모달) */}
+        Add Item
+      </AddButton>
+    </Container>
+  );
+}
+
+export default function Tab({ title, onEdit }: Props) {
+  return (
+    <Wrapper>
+      <TabHeader title={title} onEdit={onEdit} />
+      <TasksContainer />
+    </Wrapper>
+  );
+}

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { IoIosStarOutline, IoIosMore } from 'react-icons/io';
+import { IoIosStarOutline } from 'react-icons/io';
 import { CiSettings } from 'react-icons/ci';
 import { SlPlus } from 'react-icons/sl';
+import Tab from '../components/Tab';
 
 const Wrapper = styled.main`
   width: 100vw;
@@ -91,6 +92,7 @@ const UtilContainer = styled.div`
     justify-content: center;
     align-items: center;
     border-radius: 50%;
+    cursor: pointer;
   }
 `;
 
@@ -104,56 +106,12 @@ const TabGroup = styled.ul`
   position: relative;
 `;
 
-const Tab = styled.li`
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-`;
-
-const PlanHeader = styled.div`
-  padding-inline: 0.8rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .planTitle {
-    font-size: 1.126rem;
-  }
-
-  .icon {
-    cursor: pointer;
-  }
-`;
-
-const TabContainer = styled.div`
-  width: 19rem;
-  height: calc(100% - 2rem);
-  padding: 1rem;
-  border-radius: 1.1rem;
-  background-color: #ffffff;
-  position: relative;
-`;
-
 const AddTapButton = styled.button`
   background: none;
   position: absolute;
   right: 0;
   top: 50%;
   transform: translateY(-50%);
-`;
-
-const AddButton = styled.button`
-  position: absolute;
-  width: 17rem;
-  height: 3rem;
-  border-radius: 0.5rem;
-  background-color: #fafafa;
-  color: #8993a1;
-  font-weight: 600;
-  bottom: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
 `;
 
 function Plan() {
@@ -200,6 +158,10 @@ function Plan() {
     { id: 4, name: 'Team Plan3' },
   ];
 
+  const editTabInfo = () => {
+    // TODO 탭 정보 수정 및 삭제
+  };
+
   return (
     <Wrapper>
       <SideContainer>
@@ -211,6 +173,7 @@ function Plan() {
               key={item.id}
               onClick={() => {
                 setSelectedPlanName(item.name);
+                // TODO 서버에 planId로 플랜 정보 요청
               }}
             >
               {item.name}
@@ -218,13 +181,18 @@ function Plan() {
           ))}
         </PlanCategory>
         <LabelFilter>
+          {/* TODO 라벨 필터링 */}
           <span>레이블</span>
         </LabelFilter>
       </SideContainer>
       <MainContainer>
         <TopContainer>
-          <MemberFilter>member</MemberFilter>
+          <MemberFilter>
+            {/* TODO 멤버 필터링 */}
+            member
+          </MemberFilter>
           <UtilContainer>
+            {/* TODO 클릭시 즐겨찾기 토글, 설정으로 이동 */}
             <div className="icon">
               <IoIosStarOutline size={25} />
             </div>
@@ -235,21 +203,9 @@ function Plan() {
         </TopContainer>
         <TabGroup>
           {planObject.tabs.map((item) => (
-            <Tab key={item.id}>
-              <PlanHeader>
-                <span className="planTitle">{item.title}</span>
-                <span className="icon">
-                  <IoIosMore size="24" />
-                </span>
-              </PlanHeader>
-
-              <TabContainer>
-                <AddButton type="button" className="add">
-                  Add Item
-                </AddButton>
-              </TabContainer>
-            </Tab>
+            <Tab key={item.id} title={item.title} onEdit={editTabInfo} />
           ))}
+          {/* TODO 클릭시 탭 추가 */}
           <AddTapButton>
             <SlPlus size={35} color="#8993A1" />
           </AddTapButton>

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,0 +1,262 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { IoIosStarOutline, IoIosMore } from 'react-icons/io';
+import { CiSettings } from 'react-icons/ci';
+import { SlPlus } from 'react-icons/sl';
+
+const Wrapper = styled.main`
+  width: 100vw;
+  min-height: 100vh;
+  padding: 110px 70px 40px;
+  display: flex;
+  gap: 2rem;
+  background-color: #f5f5f7;
+`;
+
+const SideContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 2rem;
+`;
+
+const PlanCategory = styled.ul`
+  width: 11rem;
+  height: 50%;
+  border-radius: 1rem;
+  padding: 2.5rem 1rem;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  overflow: auto;
+  background-color: #ffffff;
+
+  li {
+    height: 3rem;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #8993a1;
+    cursor: pointer;
+
+    &.isSelected {
+      background-color: #64d4ab;
+      border-radius: 0.6rem;
+      color: #ffffff;
+    }
+  }
+`;
+
+const LabelFilter = styled.ul`
+  width: 11rem;
+  height: 50%;
+  border-radius: 1rem;
+  padding: 1rem;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffffff;
+`;
+
+const MainContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const TopContainer = styled.div`
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const MemberFilter = styled.ul`
+  width: fit-content;
+  background-color: #ffffff;
+`;
+
+const UtilContainer = styled.div`
+  display: flex;
+  gap: 0.8rem;
+
+  .icon {
+    background-color: #ffffff;
+    width: 2.8rem;
+    height: 2.8rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 50%;
+  }
+`;
+
+const TabGroup = styled.ul`
+  width: calc(100vw - 22rem);
+  height: calc(100% - 4rem);
+  padding-right: 10rem;
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  position: relative;
+`;
+
+const Tab = styled.li`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const PlanHeader = styled.div`
+  padding-inline: 0.8rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .planTitle {
+    font-size: 1.126rem;
+  }
+
+  .icon {
+    cursor: pointer;
+  }
+`;
+
+const TabContainer = styled.div`
+  width: 19rem;
+  height: calc(100% - 2rem);
+  padding: 1rem;
+  border-radius: 1.1rem;
+  background-color: #ffffff;
+  position: relative;
+`;
+
+const AddTapButton = styled.button`
+  background: none;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+const AddButton = styled.button`
+  position: absolute;
+  width: 17rem;
+  height: 3rem;
+  border-radius: 0.5rem;
+  background-color: #fafafa;
+  color: #8993a1;
+  font-weight: 600;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+`;
+
+function Plan() {
+  const [selectedPlanName, setSelectedPlanName] = useState<string>('My Plan');
+  const planObject = {
+    title: 'planting',
+    description: '안녕하세요 저희는 일정 공유 관리 서비스를 개발하고 있는 플랜팅입니다.',
+    isPublic: true,
+    members: [
+      { id: 1, name: '신우성', imgUrl: '', isAdmin: true },
+      { id: 2, name: '김태훈', imgUrl: '', isAdmin: false },
+      { id: 3, name: '허준영', imgUrl: '', isAdmin: false },
+      { id: 4, name: '한현', imgUrl: '', isAdmin: false },
+    ],
+    tabs: [
+      {
+        id: 1,
+        title: 'To do',
+        order: 0,
+        tasks: [{ title: '이펙티브 완독', labels: ['개발도서'], assignee: '허준영', order: 0 }],
+      },
+      {
+        id: 2,
+        title: 'In Progress',
+        order: 1,
+        tasks: [
+          { title: '타입스크립트 Chap1', labels: ['개발도서'], assignee: '허준영', order: 0 },
+          { title: '백준 삼성 기출', labels: ['코테'], assignee: '허준영', order: 1 },
+        ],
+      },
+      {
+        id: 3,
+        title: 'Done',
+        order: 2,
+        tasks: [{ title: 'NC SOFT 서류 제출', labels: ['이력서'], assignee: '허준영', order: 0 }],
+      },
+    ],
+  };
+
+  const planNameList = [
+    { id: 1, name: 'My Plan' },
+    { id: 2, name: 'Team Plan1' },
+    { id: 3, name: 'Team Plan2' },
+    { id: 4, name: 'Team Plan3' },
+  ];
+
+  return (
+    <Wrapper>
+      <SideContainer>
+        <PlanCategory>
+          {planNameList.map((item) => (
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+            <li
+              className={`${selectedPlanName === item.name && 'isSelected'}`}
+              key={item.id}
+              onClick={() => {
+                setSelectedPlanName(item.name);
+              }}
+            >
+              {item.name}
+            </li>
+          ))}
+        </PlanCategory>
+        <LabelFilter>
+          <span>레이블</span>
+        </LabelFilter>
+      </SideContainer>
+      <MainContainer>
+        <TopContainer>
+          <MemberFilter>member</MemberFilter>
+          <UtilContainer>
+            <div className="icon">
+              <IoIosStarOutline size={25} />
+            </div>
+            <div className="icon">
+              <CiSettings size={28} />
+            </div>
+          </UtilContainer>
+        </TopContainer>
+        <TabGroup>
+          {planObject.tabs.map((item) => (
+            <Tab key={item.id}>
+              <PlanHeader>
+                <span className="planTitle">{item.title}</span>
+                <span className="icon">
+                  <IoIosMore size="24" />
+                </span>
+              </PlanHeader>
+
+              <TabContainer>
+                <AddButton type="button" className="add">
+                  Add Item
+                </AddButton>
+              </TabContainer>
+            </Tab>
+          ))}
+          <AddTapButton>
+            <SlPlus size={35} color="#8993A1" />
+          </AddTapButton>
+        </TabGroup>
+      </MainContainer>
+    </Wrapper>
+  );
+}
+
+export default Plan;

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -4,6 +4,8 @@ import { IoIosStarOutline } from 'react-icons/io';
 import { CiSettings } from 'react-icons/ci';
 import { SlPlus } from 'react-icons/sl';
 import Tab from '../components/Tab';
+import MemberFilter from '../components/MemberFilter';
+import LabelFilter from '../components/LabelFilter';
 
 const Wrapper = styled.main`
   width: 100vw;
@@ -50,18 +52,6 @@ const PlanCategory = styled.ul`
   }
 `;
 
-const LabelFilter = styled.ul`
-  width: 11rem;
-  height: 50%;
-  border-radius: 1rem;
-  padding: 1rem;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background-color: #ffffff;
-`;
-
 const MainContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -73,11 +63,6 @@ const TopContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-`;
-
-const MemberFilter = styled.ul`
-  width: fit-content;
-  background-color: #ffffff;
 `;
 
 const UtilContainer = styled.div`
@@ -180,17 +165,13 @@ function Plan() {
             </li>
           ))}
         </PlanCategory>
-        <LabelFilter>
-          {/* TODO 라벨 필터링 */}
-          <span>레이블</span>
-        </LabelFilter>
+        <LabelFilter />
+        {/* TODO 라벨 필터링 */}
       </SideContainer>
       <MainContainer>
+        {/* TODO 멤버 필터링 */}
         <TopContainer>
-          <MemberFilter>
-            {/* TODO 멤버 필터링 */}
-            member
-          </MemberFilter>
+          <MemberFilter />
           <UtilContainer>
             {/* TODO 클릭시 즐겨찾기 토글, 설정으로 이동 */}
             <div className="icon">

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -20,9 +20,14 @@ export default createGlobalStyle`
   }
 
   button {
+    background: none;
     border: none;
     padding: 0;
     cursor: pointer;
     font-size: inherit;
+  }
+
+  ul,li{
+    list-style: none;
   }
 `;


### PR DESCRIPTION
📌 Description
- 간단하게 플랜 페이지 UI의 위치 정도만 잡아 놨습니다. 
- 탭, 라벨 및 멤버 필터링 컴포넌트 분리
- 헤더 링크 캘린더 아이콘 누르면 "/plan"으로 가도록 수정

⚠️ 주의사항
- 한 페이지에서 작업할 기능들을 나누다 보니 충돌이 생기는 걸 방지하고자 컴포넌트를 분리했습니다.
- 해야 할 일을 TODO로 써놨습니다.
- 탭 안에 할일 칸반을 아직 안 만들었어요.

close #issueNumber