### PR TITLE
[#22] 탭 추가 구현

### DIFF
--- a/public/dummy/planInfo.json
+++ b/public/dummy/planInfo.json
@@ -1,0 +1,86 @@
+{
+    "title":"planting",
+    "description":"안녕하세요 저희는 일정 공유 관리 서비스를 개발하고 있는 플랜팅입니다.",
+    "isPublic":true,
+    "members":[
+       {
+          "id":1,
+          "name":"신우성",
+          "imgUrl":"",
+          "isAdmin":true
+       },
+       {
+          "id":2,
+          "name":"김태훈",
+          "imgUrl":"",
+          "isAdmin":false
+       },
+       {
+          "id":3,
+          "name":"허준영",
+          "imgUrl":"",
+          "isAdmin":false
+       },
+       {
+          "id":4,
+          "name":"한현",
+          "imgUrl":"",
+          "isAdmin":false
+       }
+    ],
+    "tabs":[
+       {
+          "id":1,
+          "title":"To do",
+          "order":0,
+          "tasks":[
+             {
+                "title":"이펙티브 완독",
+                "labels":[
+                   "개발도서"
+                ],
+                "assignee":"허준영",
+                "order":0
+             }
+          ]
+       },
+       {
+          "id":2,
+          "title":"In Progress",
+          "order":1,
+          "tasks":[
+             {
+                "title":"타입스크립트 Chap1",
+                "labels":[
+                   "개발도서"
+                ],
+                "assignee":"허준영",
+                "order":0
+             },
+             {
+                "title":"백준 삼성 기출",
+                "labels":[
+                   "코테"
+                ],
+                "assignee":"허준영",
+                "order":1
+             }
+          ]
+       },
+       {
+          "id":3,
+          "title":"Done",
+          "order":2,
+          "tasks":[
+             {
+                "title":"NC SOFT 서류 제출",
+                "labels":[
+                   "이력서"
+                ],
+                "assignee":"허준영",
+                "order":0
+             }
+          ]
+       }
+    ]
+ }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const getPlanInfo = async () => {
+  const { data } = await axios.get('/dummy/planInfo.json');
+  return data;
+};

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,9 +1,13 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
 import { IoIosMore } from 'react-icons/io';
 
 type Props = {
   title: string;
+  // eslint-disable-next-line react/require-default-props
+  newTabTitle?: string;
+  // eslint-disable-next-line react/require-default-props
+  setNewTabTitle?: Dispatch<SetStateAction<string>>;
   onEdit: () => void;
 };
 
@@ -51,9 +55,10 @@ const AddButton = styled.button`
   transform: translateX(-50%);
 `;
 
-function TabHeader({ title, onEdit }: Props) {
+function TabHeader({ title, newTabTitle, setNewTabTitle, onEdit }: Props) {
   return (
     <Header>
+      <input type="text" value={title || newTabTitle} onChange={(e) => setNewTabTitle!(e.target.value)} />
       <span className="planTitle">{title}</span>
       <button type="button" className="icon" onClick={onEdit}>
         <IoIosMore size="24" />
@@ -75,10 +80,10 @@ function TasksContainer() {
   );
 }
 
-export default function Tab({ title, onEdit }: Props) {
+export default function Tab({ title, newTabTitle, setNewTabTitle, onEdit }: Props) {
   return (
     <Wrapper>
-      <TabHeader title={title} onEdit={onEdit} />
+      <TabHeader title={title} newTabTitle={newTabTitle} setNewTabTitle={setNewTabTitle} onEdit={onEdit} />
       <TasksContainer />
     </Wrapper>
   );

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,13 +1,9 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { IoIosMore } from 'react-icons/io';
 
 type Props = {
   title: string;
-  // eslint-disable-next-line react/require-default-props
-  newTabTitle?: string;
-  // eslint-disable-next-line react/require-default-props
-  setNewTabTitle?: Dispatch<SetStateAction<string>>;
   onEdit: () => void;
 };
 
@@ -55,10 +51,9 @@ const AddButton = styled.button`
   transform: translateX(-50%);
 `;
 
-function TabHeader({ title, newTabTitle, setNewTabTitle, onEdit }: Props) {
+function TabHeader({ title, onEdit }: Props) {
   return (
     <Header>
-      <input type="text" value={title || newTabTitle} onChange={(e) => setNewTabTitle!(e.target.value)} />
       <span className="planTitle">{title}</span>
       <button type="button" className="icon" onClick={onEdit}>
         <IoIosMore size="24" />
@@ -67,7 +62,7 @@ function TabHeader({ title, newTabTitle, setNewTabTitle, onEdit }: Props) {
   );
 }
 
-function TasksContainer() {
+export function TasksContainer() {
   return (
     <Container>
       {/* TODO 할일 칸반 리스트 */}
@@ -80,10 +75,10 @@ function TasksContainer() {
   );
 }
 
-export default function Tab({ title, newTabTitle, setNewTabTitle, onEdit }: Props) {
+export function Tab({ title, onEdit }: Props) {
   return (
     <Wrapper>
-      <TabHeader title={title} newTabTitle={newTabTitle} setNewTabTitle={setNewTabTitle} onEdit={onEdit} />
+      <TabHeader title={title} onEdit={onEdit} />
       <TasksContainer />
     </Wrapper>
   );

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -7,6 +7,33 @@ import Tab from '../components/Tab';
 import MemberFilter from '../components/MemberFilter';
 import LabelFilter from '../components/LabelFilter';
 
+interface Task {
+  title: string;
+  labels: string[];
+  assignee: string;
+  order: number;
+}
+
+type TabType = {
+  id: number;
+  title?: string;
+  order?: number;
+  tasks?: Task[];
+};
+
+type MemberType = {
+  id: number;
+  name: string;
+  imgUrl?: string;
+  isAdmin: boolean;
+};
+type PlanType = {
+  title: string;
+  description: string;
+  isPublic: boolean;
+  members: MemberType[];
+  tabs: TabType[];
+};
 const Wrapper = styled.main`
   width: 100vw;
   min-height: 100vh;
@@ -99,42 +126,44 @@ const AddTapButton = styled.button`
   transform: translateY(-50%);
 `;
 
+const planObject = {
+  title: 'planting',
+  description: '안녕하세요 저희는 일정 공유 관리 서비스를 개발하고 있는 플랜팅입니다.',
+  isPublic: true,
+  members: [
+    { id: 1, name: '신우성', imgUrl: '', isAdmin: true },
+    { id: 2, name: '김태훈', imgUrl: '', isAdmin: false },
+    { id: 3, name: '허준영', imgUrl: '', isAdmin: false },
+    { id: 4, name: '한현', imgUrl: '', isAdmin: false },
+  ],
+  tabs: [
+    {
+      id: 1,
+      title: 'To do',
+      order: 0,
+      tasks: [{ title: '이펙티브 완독', labels: ['개발도서'], assignee: '허준영', order: 0 }],
+    },
+    {
+      id: 2,
+      title: 'In Progress',
+      order: 1,
+      tasks: [
+        { title: '타입스크립트 Chap1', labels: ['개발도서'], assignee: '허준영', order: 0 },
+        { title: '백준 삼성 기출', labels: ['코테'], assignee: '허준영', order: 1 },
+      ],
+    },
+    {
+      id: 3,
+      title: 'Done',
+      order: 2,
+      tasks: [{ title: 'NC SOFT 서류 제출', labels: ['이력서'], assignee: '허준영', order: 0 }],
+    },
+  ],
+};
 function Plan() {
+  const [plan, setPlan] = useState<PlanType>(planObject);
   const [selectedPlanName, setSelectedPlanName] = useState<string>('My Plan');
-  const planObject = {
-    title: 'planting',
-    description: '안녕하세요 저희는 일정 공유 관리 서비스를 개발하고 있는 플랜팅입니다.',
-    isPublic: true,
-    members: [
-      { id: 1, name: '신우성', imgUrl: '', isAdmin: true },
-      { id: 2, name: '김태훈', imgUrl: '', isAdmin: false },
-      { id: 3, name: '허준영', imgUrl: '', isAdmin: false },
-      { id: 4, name: '한현', imgUrl: '', isAdmin: false },
-    ],
-    tabs: [
-      {
-        id: 1,
-        title: 'To do',
-        order: 0,
-        tasks: [{ title: '이펙티브 완독', labels: ['개발도서'], assignee: '허준영', order: 0 }],
-      },
-      {
-        id: 2,
-        title: 'In Progress',
-        order: 1,
-        tasks: [
-          { title: '타입스크립트 Chap1', labels: ['개발도서'], assignee: '허준영', order: 0 },
-          { title: '백준 삼성 기출', labels: ['코테'], assignee: '허준영', order: 1 },
-        ],
-      },
-      {
-        id: 3,
-        title: 'Done',
-        order: 2,
-        tasks: [{ title: 'NC SOFT 서류 제출', labels: ['이력서'], assignee: '허준영', order: 0 }],
-      },
-    ],
-  };
+  const [newTabTitle, setNewTabTitle] = useState<string>('');
 
   const planNameList = [
     { id: 1, name: 'My Plan' },
@@ -142,6 +171,13 @@ function Plan() {
     { id: 3, name: 'Team Plan2' },
     { id: 4, name: 'Team Plan3' },
   ];
+  console.log(plan);
+  const addTab = () => {
+    const newTab: TabType = {
+      id: planObject.tabs.length + 1,
+    };
+    setPlan({ ...plan, tabs: [...plan.tabs, newTab] });
+  };
 
   const editTabInfo = () => {
     // TODO 탭 정보 수정 및 삭제
@@ -184,10 +220,16 @@ function Plan() {
         </TopContainer>
         <TabGroup>
           {planObject.tabs.map((item) => (
-            <Tab key={item.id} title={item.title} onEdit={editTabInfo} />
+            <Tab
+              key={item.id}
+              title={item.title}
+              newTabTitle={newTabTitle}
+              onEdit={editTabInfo}
+              setNewTabTitle={setNewTabTitle}
+            />
           ))}
           {/* TODO 클릭시 탭 추가 */}
-          <AddTapButton>
+          <AddTapButton onClick={addTab}>
             <SlPlus size={35} color="#8993A1" />
           </AddTapButton>
         </TabGroup>

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -111,19 +111,15 @@ const UtilContainer = styled.div`
 const TabGroup = styled.ul`
   width: calc(100vw - 22rem);
   height: calc(100% - 4rem);
-  padding-right: 10rem;
   display: flex;
   gap: 1.5rem;
   overflow-x: auto;
-  position: relative;
 `;
 
 const AddTapButton = styled.button`
+  height: 100%;
   background: none;
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
+  margin-left: 5rem;
 `;
 
 const TabWrapper = styled.li`
@@ -208,6 +204,7 @@ function Plan() {
       setPlan({ ...plan!, tabs: [...plan!.tabs, newTab] });
       setIsAddingTab(false);
     }
+    // TODO newTabTitle===""일떄 enter를 누르면 탭 추가 취소
   };
 
   const editTabInfo = () => {

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -25,6 +25,9 @@ export default createGlobalStyle`
     padding: 0;
     cursor: pointer;
     font-size: inherit;
+    &:focus{
+      outline: none;
+    } 
   }
 
   ul,li{


### PR DESCRIPTION
📌 Description

- planObject가 Plan 페이지에 있는 게 복잡해서 public/dummy/planInfo.json에 넣었습니다.
- 탭 추가 버튼을 클릭하면 isAddingTab이라는 상태를 true로 변경하고 title을 입력할 input과 탭을 보여줍니다.
- input에 onKeyDonw, onBlur 이벤트가 발생할 때 plan 상태를 변경하고 서버에 요청합니다.
   - input 값이 빈 문자열이 아니고 enter를 클릭
   - input 값이 빈 문자열이 아니고 focus가 떠났을 때
   
⚠️ 주의사항

- 탭 추가를 취소하는 버튼을 만들려고 했는데 이 버튼을 클릭하면 input의 onBlur 이벤트가 발생해 handleInputBlur가 실행됩니다. 그래서 취소 버튼을 눌러도 isAddingTab이 false가 안 되고 추가가 돼버려서 일단 취소 버튼은 빼놨습니다. 추후에 다시 해볼 생각입니다.
- 탭 추가 버튼 클릭했을 때 바로 input에 포커스를 하려고 했는데 inputRef가 처음 탭 추가 버튼 클릭했을 때는 null이다가 연속으로 두 번 클릭했을 때만 포커스가 되는 이상한 현상이 있습니다.

close #22