### PR TITLE
[#29] 플랜 데이터 형태 변경에 따른 수정 및 탭 삭제 기능 구현

### DIFF
--- a/public/dummy/planInfo-1.json
+++ b/public/dummy/planInfo-1.json
@@ -1,0 +1,84 @@
+{
+    "title": "planting",
+    "description": "안녕하세요 저희는 일정 공유 관리 서비스를 개발하고 있는 플랜팅입니다.",
+    "isPublic": true,
+    "members":[
+       {
+          "id":1,
+          "name":"신우성",
+          "imgUrl":"",
+          "isAdmin":true
+       },
+       {
+          "id":2,
+          "name":"김태훈",
+          "imgUrl":"",
+          "isAdmin":false
+       },
+       {
+          "id":3,
+          "name":"허준영",
+          "imgUrl":"",
+          "isAdmin":false
+       },
+       {
+          "id":4,
+          "name":"한현",
+          "imgUrl":"",
+          "isAdmin":false
+       }
+    ],
+	"tabOrder":[2,1,3], 
+    "tabs":[
+        {
+            "id":3,
+            "title":"Done"
+         },
+       {
+          "id":1,
+          "title":"To do"
+       },
+       {
+          "id":2,
+          "title":"In Progress"
+       }
+    ],
+    "labels": [{"id":1, "value":"개발도서"},{"id":2, "value":"코테"},{"id":3, "value":"이력서"}],
+	"tasks" : [
+         {
+            "title":"NC SOFT 서류 제출",
+            "tabId": 3,
+            "labels":[
+              {"id": 3, "value":"이력서"}
+            ],
+            "assigneeId":3,
+            "order":0 
+         },
+         {
+            "title":"이펙티브 완독",
+            "tabId": 1,
+            "labels":[
+               {"id": 1, "value":"개발도서"}
+            ],
+            "assigneeId":3,
+            "order":0
+         },              {
+            "title":"타입스크립트 Chap1",
+            "tabId": 2,
+            "labels":[
+              {"id": 1, "value":"개발도서"}
+            ],
+            "assigneeId":4,
+            "order":0
+         },
+         {
+            "title":"백준 삼성 기출",
+            "tabId": 2,
+            "labels":[
+              {"id": 2, "value":"코테"}
+            ],
+            "assigneeId":1,
+            "order":1
+         }
+    ]
+ }

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
 export const getPlanInfo = async () => {
-  const { data } = await axios.get('/dummy/planInfo.json');
+  const { data } = await axios.get('/dummy/planInfo-1.json');
   return data;
 };

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 
+import { IoIosMore } from 'react-icons/io';
 import styled from 'styled-components';
 
 import defaultProfileImg from '@assets/images/defaultProfileImg.svg';
@@ -11,8 +12,19 @@ type DropdownOption = {
 };
 
 type DropdownProp = {
+  type: 'header' | 'tab';
   options: DropdownOption[];
+  onClick: () => void;
 };
+
+const Container = styled.div<{ type: string }>`
+  ${(props) =>
+    props.type === 'tab' &&
+    `
+      position: absolute;
+      right: 0.8rem;
+  `}
+`;
 
 const ProfileImg = styled.img`
   width: 50px;
@@ -22,7 +34,9 @@ const ProfileImg = styled.img`
   cursor: pointer;
 `;
 
-const DropdownList = styled.ul`
+const EditButton = styled.button``;
+
+const DropdownList = styled.ul<{ type: string }>`
   position: absolute;
   top: 80px;
   right: 38px;
@@ -32,6 +46,14 @@ const DropdownList = styled.ul`
   border: 1px solid #efefef;
   border-radius: 8px;
   background-color: white;
+  ${(props) =>
+    props.type === 'tab' &&
+    `
+    width: 5rem;
+    top: 2rem;
+    right: -0.8rem;
+    z-index: 10;
+  `}
 `;
 
 const DropdownItem = styled.li`
@@ -45,7 +67,7 @@ const DropdownItem = styled.li`
   }
 `;
 
-function Dropdown({ options }: DropdownProp) {
+function Dropdown({ type, options, onClick }: DropdownProp) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -59,8 +81,10 @@ function Dropdown({ options }: DropdownProp) {
     }
   };
 
-  const handleOptionClick = () => {
+  const handleOptionClick = (value: string) => {
     setIsOpen(false);
+
+    if (value === 'delete') onClick();
   };
 
   useEffect(() => {
@@ -71,18 +95,23 @@ function Dropdown({ options }: DropdownProp) {
   }, []);
 
   return (
-    <div ref={dropdownRef}>
-      <ProfileImg src={defaultProfileImg} alt="profile-img" onClick={toggleDropdown} />
+    <Container ref={dropdownRef} type={type}>
+      {type === 'header' && <ProfileImg src={defaultProfileImg} alt="profile-img" onClick={toggleDropdown} />}
+      {type === 'tab' && (
+        <EditButton onClick={toggleDropdown}>
+          <IoIosMore size="24" />
+        </EditButton>
+      )}
       {isOpen && (
-        <DropdownList>
+        <DropdownList type={type}>
           {options.map((option: DropdownOption) => (
-            <DropdownItem key={option.id} onClick={handleOptionClick}>
+            <DropdownItem key={option.id} onClick={() => handleOptionClick(option.value)}>
               {option.label}
             </DropdownItem>
           ))}
         </DropdownList>
       )}
-    </div>
+    </Container>
   );
 }
 

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -14,15 +14,15 @@ type DropdownOption = {
 type DropdownProp = {
   type: 'header' | 'tab';
   options: DropdownOption[];
-  onClick: () => void;
+  onClick: (value: string) => void;
 };
 
 const Container = styled.div<{ type: string }>`
   ${(props) =>
     props.type === 'tab' &&
     `
-      position: absolute;
-      right: 0.8rem;
+    position: absolute;
+    right: 0.8rem;
   `}
 `;
 
@@ -83,8 +83,8 @@ function Dropdown({ type, options, onClick }: DropdownProp) {
 
   const handleOptionClick = (value: string) => {
     setIsOpen(false);
-
-    if (value === 'delete') onClick();
+    // TODO : onClick함수가 value에 따라 다른 일을 하도록 수정
+    onClick(value);
   };
 
   useEffect(() => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,6 +83,8 @@ function Header() {
     return false;
   };
 
+  const handleDropdownClick = () => {};
+
   return (
     <HeadeContainer>
       <Logo />
@@ -97,7 +99,7 @@ function Header() {
         ))}
       </Nav>
 
-      <Dropdown options={dropdownOptions} />
+      <Dropdown type="header" options={dropdownOptions} onClick={handleDropdownClick} />
     </HeadeContainer>
   );
 }

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { IoIosMore } from 'react-icons/io';
 import styled from 'styled-components';
+
+import Dropdown from './Dropdown';
 
 interface Label {
   id: number;
@@ -49,13 +50,10 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  position: relative;
 
   .planTitle {
     font-size: 1.126rem;
-  }
-
-  .icon {
-    cursor: pointer;
   }
 `;
 
@@ -82,12 +80,12 @@ const AddButton = styled.button`
 `;
 
 function TabHeader({ title, onEdit }: TabHeaderProps) {
+  const tabEditOptions = [{ id: 1, label: '삭제', value: 'delete' }];
+
   return (
     <Header>
       <span className="planTitle">{title}</span>
-      <button type="button" className="icon" onClick={onEdit}>
-        <IoIosMore size="24" />
-      </button>
+      <Dropdown type="tab" options={tabEditOptions} onClick={onEdit} />
     </Header>
   );
 }

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -10,8 +10,9 @@ interface Label {
 
 type TaskType = {
   title: string;
+  tabId: number;
   labels: Label[];
-  assignee: string;
+  assigneeId: number;
   order: number;
 };
 

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -264,8 +264,13 @@ function Plan() {
     // TODO newTabTitle===""일떄 enter를 누르면 탭 추가 취소
   };
 
-  const editTabInfo = () => {
-    // TODO 탭 정보 수정 및 삭제
+  const deleteTabById = (tabId: number) => {
+    if (plan) {
+      const updatedTabOrder = plan.tabOrder.filter((item) => item !== tabId);
+      const updatedPlan = { ...plan, tabOrder: updatedTabOrder, tabs: plan.tabs.filter((tab) => tab.id !== tabId) };
+      setPlan(updatedPlan);
+      // TODO: 서버에 tabId로 삭제 요청
+    }
   };
 
   const handleChangeLabel = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -317,7 +322,7 @@ function Plan() {
             <Tab
               key={item.id}
               title={item.title!}
-              onEdit={editTabInfo}
+              onEdit={() => deleteTabById(item.id)}
               tasks={(item as ArrangedTab).tasks!}
               onClickHandler={openModal}
             />

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -265,7 +265,7 @@ function Plan() {
     // TODO newTabTitle===""일떄 enter를 누르면 탭 추가 취소
   };
 
-  const deleteTabById = (tabId: number) => {
+  const handleDeleteTab = (tabId: number) => {
     if (plan) {
       const updatedTabOrder = plan.tabOrder.filter((item) => item !== tabId);
       const updatedPlan = { ...plan, tabOrder: updatedTabOrder, tabs: plan.tabs.filter((tab) => tab.id !== tabId) };
@@ -323,7 +323,7 @@ function Plan() {
             <Tab
               key={item.id}
               title={item.title!}
-              onEdit={() => deleteTabById(item.id)}
+              onEdit={() => handleDeleteTab(item.id)}
               tasks={(item as ArrangedTab).tasks!}
               onClickHandler={openModal}
             />
@@ -342,8 +342,8 @@ function Plan() {
               <TasksContainer onClickHandler={openModal} />
             </TabWrapper>
           )}
-          <AddTapButton onClick={handleAddStatus}>
-            <SlPlus size={35} color="#8993A1" />
+          <AddTapButton>
+            <SlPlus size={35} color="#8993A1" onClick={handleAddStatus} />
           </AddTapButton>
         </TabGroup>
       </MainContainer>

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -180,19 +180,25 @@ function Plan() {
   const { Modal, showModal, openModal, closeModal } = useModal();
   const [selectedLabels, setSelectedLabel] = useState<number[]>([]);
 
-  const filterPlanByLabels = (data: PlanType, labels: number[]) => {
-    // if (!data || !labels || labels.length === 0) {
-    //   console.log('뭐야');
-    //   return data;
-    // }
+  const sortTabsAndFilterPlanByLabels = (data: PlanType, labels: number[]) => {
+    if (!data) {
+      return data;
+    }
 
+    let filteredByLabelTasks = data.tasks;
+
+    // 라벨 배렬의 길이가 0보다 클때만 라벨 필터링
+    if (labels.length > 0) {
+      filteredByLabelTasks = data.tasks.filter((task) => task.labels.some((label) => labels.includes(label.id)));
+    }
+
+    // {3: id=3인 탭, 1: id=1인 탭, 2:id=2인 탭}
     const tabIndex: Record<number, ArrangedTab> = {};
     data.tabs.forEach((tab) => {
       tabIndex[tab.id] = { ...tab, tasks: [] };
     });
 
-    // Group tasks by tabId
-    data.tasks.forEach((task) => {
+    filteredByLabelTasks.forEach((task) => {
       const tab = tabIndex[task.tabId];
       if (tab) {
         tab.tasks!.push(task);
@@ -204,18 +210,6 @@ function Plan() {
       return tab;
     });
 
-    console.log(labels);
-    // const updatedTabs = data.tabs.map((tab) => ({
-    //   ...tab,
-    //   tasks: tab.tasks?.filter((task) =>
-    //     task.labels.some((label) => {
-    //       // console.log(selectedLabels, label.id, selectedLabels.includes(label.id));
-    //       return selectedLabels.includes(label.id);
-    //     }),
-    //   ),
-    // }));
-
-    // return { ...data, tabs: updatedTabs };
     return { ...data, tabs: arrangedTabs };
   };
 
@@ -224,9 +218,9 @@ function Plan() {
       try {
         const data = await getPlanInfo();
 
-        // 라벨 필터링된 데이터를 가져옴
-        const filteredPlan = filterPlanByLabels(data, selectedLabels);
-        setPlan(filteredPlan);
+        // 탭 정렬 및 라벨 필터링된 데이터를 가져옴
+        const sortedTabsAndfilteredPlan = sortTabsAndFilterPlanByLabels(data, selectedLabels);
+        setPlan(sortedTabsAndfilteredPlan);
       } catch (err) {
         throw new Error('플랜 정보를 가져오는데 실패했습니다.');
       }


### PR DESCRIPTION
📌 Description
- dummy에 planInfo-1.json을 추가했습니다. (변경된 형태의 데이터)
- 데이터 모양에 맞게 수정했습니다.
  - tabOrder에 맞춰 tabs를 정렬
  - 받아온 데이터를 가공해서 tasks를 tabId별로 분류해서 tabs에 넣었습니다.
  - 데이터를 가공 후 setPlan하도록 했습니다.
- 탭 삭제 기능 구현
  - more 아이콘을 누르면 드롭다운이 나오고 삭제할 수 있습니다.
  - 드롭다운 옵션을 클릭했을 때 할 일을 onClick함수로 주고 있는데 value로 어떤 일을 해야 할지 구분할 예정입니다.

⚠️ 주의사항
- 제가 생각하기에 프론트에서 사용하기 좋은 방식은 이전 데이터 형태라고 생각해서 fetch하자마자 가공하고 setPlan했습니다. 그대로 setPlan하고 그리기 전에 탭 정렬, tabId별로 tasks를 분리하는 것 보다 가공하는데 시간이 걸리더라도 잠깐 로딩? 보여줬다가 보여 주는게 낫지 않을까 생각했습니다.  준영님이 어떻게 생각하시는지 궁금해요!

close #29