### PR TITLE
[#47] 할일 아이템 구현

### DIFF
--- a/public/dummy/planInfo.json
+++ b/public/dummy/planInfo.json
@@ -35,6 +35,7 @@
           "order":0,
           "tasks":[
              {
+                "id": 0,
                 "title":"이펙티브 완독",
                 "labels":[
                    {"id": 1, "value":"개발도서"}
@@ -50,6 +51,7 @@
           "order":1,
           "tasks":[
              {
+               "id": 2,
                 "title":"타입스크립트 Chap1",
                 "labels":[
                   {"id": 1, "value":"개발도서"}
@@ -58,6 +60,7 @@
                 "order":0
              },
              {
+               "id": 3,
                 "title":"백준 삼성 기출",
                 "labels":[
                   {"id": 2, "value":"코테"}
@@ -73,6 +76,7 @@
           "order":2,
           "tasks":[
              {
+                "id": 1,
                 "title":"NC SOFT 서류 제출",
                 "labels":[
                   {"id": 3, "value":"이력서"}

--- a/public/dummy/planInfo.json
+++ b/public/dummy/planInfo.json
@@ -41,7 +41,8 @@
                    {"id": 1, "value":"개발도서"}
                 ],
                 "assignee":"허준영",
-                "order":0
+                "order":0,
+                "dateRange": ["2023-10-20", "2023-10-27"]
              }
           ]
        },
@@ -57,7 +58,8 @@
                   {"id": 1, "value":"개발도서"}
                 ],
                 "assignee":"허준영",
-                "order":0
+                "order":0,
+                "dateRange": ["2023-10-12", "2023-10-20"]
              },
              {
                "id": 3,
@@ -66,7 +68,8 @@
                   {"id": 2, "value":"코테"}
                 ],
                 "assignee":"허준영",
-                "order":1
+                "order":1,
+                "dateRange": null
              }
           ]
        },
@@ -82,7 +85,8 @@
                   {"id": 3, "value":"이력서"}
                 ],
                 "assignee":"허준영",
-                "order":0
+                "order":0,
+                "dateRange": ["2023-10-10", "2023-10-12"]
              }
           ]
        }

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { IoClose } from 'react-icons/io5';
+import styled from 'styled-components';
+
+import { hashStringToColor } from '@utils';
+
+const LabelItem = styled.li<{ height: number; color: string }>`
+  list-style: none;
+  position: relative;
+  padding: 0.5rem 1rem;
+  height: ${(prop) => prop.height}rem;
+  border-radius: 10px;
+  color: white;
+  text-align: center;
+  line-height: 110%;
+  background-color: ${(prop) => prop.color};
+
+  button {
+    display: none;
+    width: 1rem;
+    height: 1rem;
+    position: absolute;
+    bottom: 1rem;
+    right: -0.3rem;
+    color: #f44336;
+    background-color: white;
+    border: 1px solid lightgray;
+    border-radius: 50%;
+    line-height: 110%;
+  }
+  &:hover button {
+    display: flex;
+  }
+`;
+
+// TODO: Label이라는 interface가 존재하는데 이름을 다시 정해야 함
+interface LabelInfo {
+  id: number;
+  value: string;
+}
+
+interface Props {
+  height: number;
+  labelInfo: LabelInfo;
+  deleteHandler: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export default function Label({ height, labelInfo, deleteHandler }: Props) {
+  return (
+    <LabelItem id={labelInfo.id.toString()} height={height} color={hashStringToColor(labelInfo.id.toString())}>
+      <span>{labelInfo.value}</span>
+      <button id={`delete-${labelInfo.value}`} type="button" onClick={deleteHandler}>
+        <IoClose />
+      </button>
+    </LabelItem>
+  );
+}

--- a/src/components/LabelInput.tsx
+++ b/src/components/LabelInput.tsx
@@ -92,7 +92,10 @@ export default function LabelInput({ allLabels, alreadySelected, selectedLabelsH
       alert('이미 등록된 레이블입니다!');
       return;
     }
-    if (isIncludeIn(allLabels, currentLabel) === false) allLabels.push(currentLabel);
+    if (isIncludeIn(allLabels, currentLabel) === false) {
+      // TODO: label을 plan에 등록하는 API 요청
+      allLabels.push(currentLabel);
+    }
 
     setSearched(allLabels);
     setSelected([...selected, currentLabel]);

--- a/src/components/LabelInput.tsx
+++ b/src/components/LabelInput.tsx
@@ -72,11 +72,8 @@ export default function LabelInput({ allLabels, alreadySelected, selectedLabelsH
   const labelInput = useRef<HTMLInputElement>(null);
   const searchWindowRef = useRef<HTMLDivElement>(null);
   const currentSearchedRef = useRef<HTMLButtonElement>(null);
-  // const scrollRef = useRef<HTMLButtonElement[]>([]);
   const [searched, setSearched] = useState<string[]>(allLabels);
   const [selected, setSelected] = useState<string[]>(alreadySelected);
-  // TODO: 새로 추가된 라벨들을 서버에 따로 보내줘야하지 않을까 해서 만든 상태
-  // const [newLabels, setNewLabels] = useState<string[]>([]);
   const [searchedIdx, setSearchedIdx] = useState<number>(-1);
   const [showSearchLabel, setShowSearchLabel] = useState<boolean>(false);
 

--- a/src/components/LabelInput.tsx
+++ b/src/components/LabelInput.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useRef, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -71,6 +71,8 @@ interface Props {
 export default function LabelInput({ allLabels, alreadySelected, selectedLabelsHandler }: Props) {
   const labelInput = useRef<HTMLInputElement>(null);
   const searchWindowRef = useRef<HTMLDivElement>(null);
+  const currentSearchedRef = useRef<HTMLButtonElement>(null);
+  // const scrollRef = useRef<HTMLButtonElement[]>([]);
   const [searched, setSearched] = useState<string[]>(allLabels);
   const [selected, setSelected] = useState<string[]>(alreadySelected);
   // TODO: 새로 추가된 라벨들을 서버에 따로 보내줘야하지 않을까 해서 만든 상태
@@ -142,6 +144,16 @@ export default function LabelInput({ allLabels, alreadySelected, selectedLabelsH
     setSelected(updateLabels);
   };
 
+  useEffect(() => {
+    const moveToSearched = () => {
+      currentSearchedRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+    };
+    moveToSearched();
+  }, [searchedIdx]);
+
   return (
     <label htmlFor="task-label-input">
       레이블
@@ -178,6 +190,7 @@ export default function LabelInput({ allLabels, alreadySelected, selectedLabelsH
                   key={label}
                   type="button"
                   $isFocus={idx === searchedIdx}
+                  ref={idx === searchedIdx ? currentSearchedRef : null}
                   onMouseDown={onClickSearchedLabel}
                   onMouseOver={() => setSearchedIdx(idx)}
                   onMouseOut={() => setSearchedIdx(-1)}

--- a/src/components/LabelInput.tsx
+++ b/src/components/LabelInput.tsx
@@ -1,0 +1,188 @@
+import React, { Dispatch, SetStateAction, useRef, useState } from 'react';
+
+import styled from 'styled-components';
+
+import Label from '@components/Label';
+
+const LabelsWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+
+  #label-search {
+    position: absolute;
+    width: 100%;
+    max-height: 10rem;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    border-top: 1px solid lightgray;
+    border-radius: 0 0 8px 8px;
+    background-color: #fafafa;
+  }
+
+  #no-coincide-label {
+    padding: 1rem;
+  }
+`;
+
+const LabelsContainer = styled.div`
+  height: 5rem;
+  padding: 0.3rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  overflow: auto;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: #fafafa;
+  border-radius: 8px;
+  font-size: 0.9rem;
+
+  #labels {
+    padding: 1rem 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    overflow: auto;
+    gap: 0.5rem;
+  }
+
+  #task-label-input {
+    width: 5rem;
+    height: 2rem;
+  }
+`;
+
+const SearchedLabel = styled.button<{ $isFocus: boolean }>`
+  padding: 0.5rem 1rem;
+  border: 0;
+  background-color: ${(prop) => (prop.$isFocus ? 'rgb(127, 127, 127, 0.3)' : 'transparent')};
+  text-align: start;
+`;
+
+interface Props {
+  allLabels: string[];
+  alreadySelected: string[];
+  selectedLabelsHandler: Dispatch<SetStateAction<string[]>>;
+}
+
+export default function LabelInput({ allLabels, alreadySelected, selectedLabelsHandler }: Props) {
+  const labelInput = useRef<HTMLInputElement>(null);
+  const searchWindowRef = useRef<HTMLDivElement>(null);
+  const [searched, setSearched] = useState<string[]>(allLabels);
+  const [selected, setSelected] = useState<string[]>(alreadySelected);
+  // TODO: 새로 추가된 라벨들을 서버에 따로 보내줘야하지 않을까 해서 만든 상태
+  // const [newLabels, setNewLabels] = useState<string[]>([]);
+  const [searchedIdx, setSearchedIdx] = useState<number>(-1);
+  const [showSearchLabel, setShowSearchLabel] = useState<boolean>(false);
+
+  const searchLabelName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.currentTarget.value.length === 0) setSearched(allLabels);
+    else setSearched(allLabels.filter((label) => label.includes(e.currentTarget.value)));
+  };
+
+  const isIncludeIn = (labelArr: string[], currentLabel: string) => {
+    return labelArr.includes(currentLabel);
+  };
+
+  const addLabel = (currentLabel: string) => {
+    if (isIncludeIn(selected, currentLabel)) {
+      // eslint-disable-next-line
+      alert('이미 등록된 레이블입니다!');
+      return;
+    }
+    if (isIncludeIn(allLabels, currentLabel) === false) allLabels.push(currentLabel);
+
+    setSearched(allLabels);
+    setSelected([...selected, currentLabel]);
+    selectedLabelsHandler([...selected, currentLabel]);
+    labelInput.current!.value = '';
+  };
+
+  const onKeyDownInlabelInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (searched.length > 0) {
+      if (e.key === 'ArrowDown') {
+        setSearchedIdx((prev) => (prev + 1 >= searched.length ? 0 : prev + 1));
+      }
+      if (e.key === 'ArrowUp') {
+        setSearchedIdx((prev) => (prev - 1 < 0 ? searched.length - 1 : prev - 1));
+      }
+    }
+    if (e.key === 'Escape') {
+      setSearchedIdx(-1);
+      setShowSearchLabel(false);
+    }
+    if (e.key === 'Enter') {
+      if (labelInput.current === null) return;
+      if (labelInput.current.value.length === 0) {
+        if (searchedIdx < 0) {
+          // eslint-disable-next-line
+          alert('최소 1글자 이상 입력해주세요!');
+          return;
+        }
+        addLabel(searched[searchedIdx]);
+        return;
+      }
+      addLabel(labelInput.current.value);
+    }
+  };
+
+  const onClickSearchedLabel = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    const currentLabel = searched[searchedIdx];
+    addLabel(currentLabel);
+  };
+
+  const onClickDeleteLabel = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const target = e.currentTarget.id.split('-')[1];
+    const updateLabels = selected.filter((label) => label !== target);
+    setSelected(updateLabels);
+  };
+
+  return (
+    <label htmlFor="task-label-input">
+      레이블
+      <LabelsWrapper>
+        <LabelsContainer>
+          <ul id="labels">
+            {selected.map((label, idx) => (
+              <Label key={label} height={2} labelInfo={{ id: idx, value: label }} deleteHandler={onClickDeleteLabel} />
+            ))}
+            <input
+              id="task-label-input"
+              type="text"
+              autoComplete="off"
+              onKeyDown={onKeyDownInlabelInput}
+              onFocus={() => setShowSearchLabel(true)}
+              onBlur={() => setShowSearchLabel(false)}
+              onChange={searchLabelName}
+              ref={labelInput}
+            />
+          </ul>
+        </LabelsContainer>
+        {showSearchLabel && (
+          <div id="label-search" ref={searchWindowRef}>
+            {searched.length === 0 ? (
+              <p id="no-coincide-label">일치하는 레이블이 없습니다.</p>
+            ) : (
+              searched.map((label, idx) => (
+                <SearchedLabel
+                  key={label}
+                  type="button"
+                  $isFocus={idx === searchedIdx}
+                  onMouseDown={onClickSearchedLabel}
+                  onMouseOver={() => setSearchedIdx(idx)}
+                  onMouseOut={() => setSearchedIdx(-1)}
+                >
+                  {label}
+                </SearchedLabel>
+              ))
+            )}
+          </div>
+        )}
+      </LabelsWrapper>
+    </label>
+  );
+}

--- a/src/components/LabelInput.tsx
+++ b/src/components/LabelInput.tsx
@@ -115,6 +115,7 @@ export default function LabelInput({ allLabels, alreadySelected, selectedLabelsH
       setShowSearchLabel(false);
     }
     if (e.key === 'Enter') {
+      e.preventDefault();
       if (labelInput.current === null) return;
       if (labelInput.current.value.length === 0) {
         if (searchedIdx < 0) {

--- a/src/components/LabelInput.tsx
+++ b/src/components/LabelInput.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch, SetStateAction, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
-import Label from '@components/Label';
+import LabelItem from '@components/LabelItem';
 
 const LabelsWrapper = styled.div`
   position: relative;
@@ -148,7 +148,12 @@ export default function LabelInput({ allLabels, alreadySelected, selectedLabelsH
         <LabelsContainer>
           <ul id="labels">
             {selected.map((label, idx) => (
-              <Label key={label} height={2} labelInfo={{ id: idx, value: label }} deleteHandler={onClickDeleteLabel} />
+              <LabelItem
+                key={label}
+                height={2}
+                labelInfo={{ id: idx, value: label }}
+                deleteHandler={onClickDeleteLabel}
+              />
             ))}
             <input
               id="task-label-input"

--- a/src/components/LabelItem.tsx
+++ b/src/components/LabelItem.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { hashStringToColor } from '@utils';
 
-const LabelItem = styled.li<{ height: number; color: string }>`
+const LabelContainer = styled.li<{ height: number; color: string }>`
   list-style: none;
   position: relative;
   padding: 0.5rem 1rem;
@@ -34,25 +34,24 @@ const LabelItem = styled.li<{ height: number; color: string }>`
   }
 `;
 
-// TODO: Label이라는 interface가 존재하는데 이름을 다시 정해야 함
-interface LabelInfo {
+interface Label {
   id: number;
   value: string;
 }
 
 interface Props {
   height: number;
-  labelInfo: LabelInfo;
+  labelInfo: Label;
   deleteHandler: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export default function Label({ height, labelInfo, deleteHandler }: Props) {
+export default function LabelItem({ height, labelInfo, deleteHandler }: Props) {
   return (
-    <LabelItem id={labelInfo.id.toString()} height={height} color={hashStringToColor(labelInfo.id.toString())}>
+    <LabelContainer id={labelInfo.id.toString()} height={height} color={hashStringToColor(labelInfo.id.toString())}>
       <span>{labelInfo.value}</span>
       <button id={`delete-${labelInfo.value}`} type="button" onClick={deleteHandler}>
         <IoClose />
       </button>
-    </LabelItem>
+    </LabelContainer>
   );
 }

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -1,13 +1,12 @@
 import React, { useRef, useState } from 'react';
 
-import { IoClose } from 'react-icons/io5';
 import styled from 'styled-components';
 
 import { ReactComponent as DeadlineDate } from '@assets/images/deadlineCheck.svg';
 import { ReactComponent as StartDate } from '@assets/images/startDate.svg';
+import Label from '@components/Label';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
-import { hashStringToColor } from '@utils';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -146,35 +145,6 @@ const LabelsContainer = styled.div`
   #task-label-input {
     width: 5rem;
     height: 2rem;
-  }
-`;
-
-const LabelItem = styled.li<{ color: string }>`
-  list-style: none;
-  position: relative;
-  padding: 0.5rem 1rem;
-  height: 80%;
-  border-radius: 10px;
-  color: white;
-  text-align: center;
-  line-height: 100%;
-  background-color: ${(prop) => prop.color};
-
-  button {
-    display: none;
-    width: 1rem;
-    height: 1rem;
-    position: absolute;
-    bottom: 1rem;
-    right: -0.3rem;
-    color: #f44336;
-    background-color: white;
-    border: 1px solid lightgray;
-    border-radius: 50%;
-    line-height: 110%;
-  }
-  &:hover button {
-    display: flex;
   }
 `;
 
@@ -354,13 +324,13 @@ export default function AddTaskModal({ members, allLabels }: Props) {
             <LabelsWrapper>
               <LabelsContainer>
                 <ul id="labels">
-                  {selectedLabels.map((label) => (
-                    <LabelItem key={label} color={hashStringToColor(label)}>
-                      <span>{label}</span>
-                      <button id={`delete-${label}`} type="button" onClick={onClickDeleteLabel}>
-                        <IoClose />
-                      </button>
-                    </LabelItem>
+                  {selectedLabels.map((label, idx) => (
+                    <Label
+                      key={label}
+                      height={2}
+                      labelInfo={{ id: idx, value: label }}
+                      deleteHandler={onClickDeleteLabel}
+                    />
                   ))}
                   <input
                     id="task-label-input"

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
 import { ReactComponent as DeadlineDate } from '@assets/images/deadlineCheck.svg';
 import { ReactComponent as StartDate } from '@assets/images/startDate.svg';
-import Label from '@components/Label';
+import LabelInput from '@components/LabelInput';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
 
@@ -97,64 +97,6 @@ const DeadlineField = styled.div`
   }
 `;
 
-const LabelsWrapper = styled.div`
-  position: relative;
-  width: 100%;
-  height: 100%;
-
-  #label-search {
-    position: absolute;
-    width: 100%;
-    max-height: 10rem;
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    border-top: 1px solid lightgray;
-    border-radius: 0 0 8px 8px;
-    background-color: #fafafa;
-  }
-
-  #no-coincide-label {
-    padding: 1rem;
-  }
-`;
-
-const LabelsContainer = styled.div`
-  height: 5rem;
-  padding: 0.3rem 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  overflow: auto;
-  align-items: center;
-  gap: 0.5rem;
-  background-color: #fafafa;
-  border-radius: 8px;
-  font-size: 0.9rem;
-
-  #labels {
-    padding: 1rem 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    overflow: auto;
-    gap: 0.5rem;
-  }
-
-  #task-label-input {
-    width: 5rem;
-    height: 2rem;
-  }
-`;
-
-const SearchedLabel = styled.button<{ $isFocus: boolean }>`
-  padding: 0.5rem 1rem;
-  border: 0;
-  background-color: ${(prop) => (prop.$isFocus ? 'rgb(127, 127, 127, 0.3)' : 'transparent')};
-  text-align: start;
-`;
-
 interface Props {
   members: string[][];
   allLabels: string[];
@@ -163,9 +105,6 @@ interface Props {
 export default function AddTaskModal({ members, allLabels }: Props) {
   const today = new Date();
 
-  const labelInput = useRef<HTMLInputElement>(null);
-  const searchWindowRef = useRef<HTMLDivElement>(null);
-
   const [taskName, setTaskName] = useState<string>('');
   const [assignee, setAssignee] = useState<string>('');
   const [checkDeadline, setCheckDeadline] = useState<boolean>(false);
@@ -173,12 +112,7 @@ export default function AddTaskModal({ members, allLabels }: Props) {
     [today.getFullYear(), today.getMonth() + 1, today.getDate()].join('-'),
   );
   const [endDate, setEndDate] = useState<string>(startDate);
-  const [searchedLabels, setSearchedLabels] = useState<string[]>(allLabels);
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
-  // TODO: 새로 추가된 라벨들을 서버에 따로 보내줘야하지 않을까 해서 만든 상태
-  // const [newLabels, setNewLabels] = useState<string[]>([]);
-  const [showSearchLabel, setShowSearchLabel] = useState<boolean>(false);
-  const [searchedLabelIdx, setSearchedLabelIdx] = useState<number>(-1);
 
   const options = members.map((member) => {
     return { value: member[1], label: member[0] };
@@ -196,67 +130,6 @@ export default function AddTaskModal({ members, allLabels }: Props) {
       setStartDate(e.currentTarget.value);
     }
     setEndDate(e.currentTarget.value);
-  };
-
-  const searchLabelName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.currentTarget.value.length === 0) setSearchedLabels(allLabels);
-    else setSearchedLabels(allLabels.filter((label) => label.includes(e.currentTarget.value)));
-  };
-
-  const isIncludeIn = (labelArr: string[], currentLabel: string) => {
-    return labelArr.includes(currentLabel);
-  };
-
-  const addLabel = (currentLabel: string) => {
-    if (isIncludeIn(selectedLabels, currentLabel)) {
-      // eslint-disable-next-line
-      alert('이미 등록된 레이블입니다!');
-      return;
-    }
-    if (isIncludeIn(allLabels, currentLabel) === false) allLabels.push(currentLabel);
-    setSearchedLabels(allLabels);
-    setSelectedLabels([...selectedLabels, currentLabel]);
-    labelInput.current!.value = '';
-  };
-
-  const onKeyDownInlabelInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (searchedLabels.length > 0) {
-      if (e.key === 'ArrowDown') {
-        setSearchedLabelIdx((prev) => (prev + 1 >= searchedLabels.length ? 0 : prev + 1));
-      }
-      if (e.key === 'ArrowUp') {
-        setSearchedLabelIdx((prev) => (prev - 1 < 0 ? searchedLabels.length - 1 : prev - 1));
-      }
-    }
-    if (e.key === 'Escape') {
-      setSearchedLabelIdx(-1);
-      setShowSearchLabel(false);
-    }
-    if (e.key === 'Enter') {
-      if (labelInput.current === null) return;
-      if (labelInput.current.value.length === 0) {
-        if (searchedLabelIdx < 0) {
-          // eslint-disable-next-line
-          alert('최소 1글자 이상 입력해주세요!');
-          return;
-        }
-        addLabel(searchedLabels[searchedLabelIdx]);
-        return;
-      }
-      addLabel(labelInput.current.value);
-    }
-  };
-
-  const onClickSearchedLabel = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    const currentLabel = searchedLabels[searchedLabelIdx];
-    addLabel(currentLabel);
-  };
-
-  const onClickDeleteLabel = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const target = e.currentTarget.id.split('-')[1];
-    const updateLabels = selectedLabels.filter((label) => label !== target);
-    setSelectedLabels(updateLabels);
   };
 
   const submitAddTask = (e: React.FormEvent<HTMLFormElement>) => {
@@ -319,53 +192,7 @@ export default function AddTaskModal({ members, allLabels }: Props) {
           </DeadlineField>
         </Fields>
         <InputField>
-          <label htmlFor="task-label-input">
-            레이블
-            <LabelsWrapper>
-              <LabelsContainer>
-                <ul id="labels">
-                  {selectedLabels.map((label, idx) => (
-                    <Label
-                      key={label}
-                      height={2}
-                      labelInfo={{ id: idx, value: label }}
-                      deleteHandler={onClickDeleteLabel}
-                    />
-                  ))}
-                  <input
-                    id="task-label-input"
-                    type="text"
-                    autoComplete="off"
-                    onKeyDown={onKeyDownInlabelInput}
-                    onFocus={() => setShowSearchLabel(true)}
-                    onBlur={() => setShowSearchLabel(false)}
-                    onChange={searchLabelName}
-                    ref={labelInput}
-                  />
-                </ul>
-              </LabelsContainer>
-              {showSearchLabel && (
-                <div id="label-search" ref={searchWindowRef}>
-                  {searchedLabels.length === 0 ? (
-                    <p id="no-coincide-label">일치하는 레이블이 없습니다.</p>
-                  ) : (
-                    searchedLabels.map((label, idx) => (
-                      <SearchedLabel
-                        key={label}
-                        type="button"
-                        $isFocus={idx === searchedLabelIdx}
-                        onMouseDown={onClickSearchedLabel}
-                        onMouseOver={() => setSearchedLabelIdx(idx)}
-                        onMouseOut={() => setSearchedLabelIdx(-1)}
-                      >
-                        {label}
-                      </SearchedLabel>
-                    ))
-                  )}
-                </div>
-              )}
-            </LabelsWrapper>
-          </label>
+          <LabelInput allLabels={allLabels} alreadySelected={[]} selectedLabelsHandler={setSelectedLabels} />
         </InputField>
         <ModalButton type="submit">추가하기</ModalButton>
       </FormContainer>

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import styled from 'styled-components';
+import { MemberType } from 'types';
 
 import { ReactComponent as DeadlineDate } from '@assets/images/deadlineCheck.svg';
 import { ReactComponent as StartDate } from '@assets/images/startDate.svg';
@@ -98,7 +99,7 @@ const DeadlineField = styled.div`
 `;
 
 interface Props {
-  members: string[][];
+  members: MemberType[];
   allLabels: string[];
 }
 
@@ -115,7 +116,7 @@ export default function AddTaskModal({ members, allLabels }: Props) {
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
 
   const options = members.map((member) => {
-    return { value: member[1], label: member[0] };
+    return { value: member.id.toString(), label: member.name };
   });
 
   const changeStartDate = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -139,7 +139,7 @@ export default function AddTaskModal({ members, allLabels }: Props) {
     const requestData = {
       taskName,
       assignee,
-      dateRange: checkDeadline ? [null, null] : [startDate, endDate],
+      dateRange: checkDeadline ? [startDate, endDate] : [null, null],
       selectedLabels,
     };
     // eslint-disable-next-line

--- a/src/components/Modal/ExitPlan.tsx
+++ b/src/components/Modal/ExitPlan.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import styled from 'styled-components';
+import { MemberType } from 'types';
 
 import { ModalButton, ModalButtonContainer, ModalDescription } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
@@ -17,7 +18,7 @@ const SelectAdminText = styled.p`
 
 interface ExitPlanProps {
   description: string;
-  members: string[][];
+  members: MemberType[];
   requestAPI: () => void;
   onClose: () => void;
 }
@@ -26,7 +27,7 @@ interface ExitPlanProps {
 export default function ExitPlanModal({ description, members, requestAPI, onClose }: ExitPlanProps) {
   const [admin, setAdmin] = useState<string>('');
   const options = members.map((member) => {
-    return { value: member[1], label: member[0] };
+    return { value: member.id.toString(), label: member.name };
   });
 
   // eslint-disable-next-line

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -38,14 +38,21 @@ const ModalContainer = styled.div`
   justify-content: space-between;
 `;
 
-type ModalType = 'normal' | 'exitPlan' | 'addTask';
+type ModalType = 'none' | 'normal' | 'exitPlan' | 'addTask';
+
+interface MemberType {
+  id: number;
+  name: string;
+  imgUrl?: string;
+  isAdmin: boolean;
+}
 
 interface Props {
   type: ModalType;
   description?: string;
   requestAPI: () => void;
   onClose: () => void;
-  members?: string[][];
+  members?: MemberType[];
   allLabels?: string[];
 }
 
@@ -59,6 +66,7 @@ export default function Modal({ type, description, requestAPI, onClose, members,
     window.addEventListener('keydown', keyDownEscCloseModal);
     return () => window.removeEventListener('keydown', keyDownEscCloseModal);
   }, []);
+
   return (
     <ModalPortal>
       <ModalOverlay onClick={onClose}>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -2,8 +2,8 @@ import React, { useState, useRef } from 'react';
 
 import styled from 'styled-components';
 
-import TaskItem from './TaskItem';
 import Dropdown from './Dropdown';
+import TaskItem from './TaskItem';
 
 interface Label {
   id: number;

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -9,6 +9,7 @@ interface Label {
 }
 
 type TaskType = {
+  id: number;
   title: string;
   labels: Label[];
   assignee: string;

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { IoIosMore } from 'react-icons/io';
 import styled from 'styled-components';
 
+import TaskItem from './TaskItem';
+
 interface Label {
   id: number;
   value: string;
@@ -14,6 +16,7 @@ type TaskType = {
   labels: Label[];
   assignee: string;
   order: number;
+  dateRange: null | string[];
 };
 
 type TabProps = {
@@ -60,12 +63,17 @@ const Header = styled.div`
 `;
 
 const Container = styled.div`
-  width: 19rem;
+  width: 20rem;
   height: calc(100% - 2rem);
   padding: 1rem;
   border-radius: 1.1rem;
   background-color: #ffffff;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  overflow: auto;
 `;
 
 const AddButton = styled.button`
@@ -96,7 +104,8 @@ export function TasksContainer({ tasks, onClickHandler }: TaskContainerProps) {
   return (
     <Container>
       {/* TODO 할일 칸반 리스트 */}
-      {tasks?.map((item) => <span key={item.order}>{item.title}</span>)}
+      {/* {tasks?.map((item) => <span key={item.order}>{item.title}</span>)} */}
+      {tasks?.map((task) => <TaskItem key={task.id} task={task} />)}
       {/* TODO 할일 drag&drop */}
       <AddButton type="button" className="add" onClick={onClickHandler}>
         {/* TODO 클릭시 일정 추가(모달) */}

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -15,6 +15,7 @@ type TaskType = {
   title: string;
   tabId: number;
   labels: Label[];
+  assignee: string;
   assigneeId: number;
   order: number;
   dateRange: null | string[];

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { IoClose } from 'react-icons/io5';
 import { PiClockFill } from 'react-icons/pi';
 import { RiInfinityLine } from 'react-icons/ri';
 import styled from 'styled-components';
@@ -7,6 +8,7 @@ import styled from 'styled-components';
 import { hashStringToColor } from '@utils';
 
 const ItemWrapper = styled.div`
+  position: relative;
   padding: 1rem;
   width: 18rem;
   min-height: 8rem;
@@ -21,8 +23,22 @@ const ItemWrapper = styled.div`
     word-wrap: break-word;
   }
 
+  button {
+    display: none;
+    width: 1rem;
+    height: 1rem;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    color: #f44336;
+  }
+
   &:hover {
     background-color: #ececec;
+  }
+
+  &:hover button {
+    display: flex;
   }
 `;
 
@@ -81,6 +97,9 @@ interface Props {
 export default function TaskItem({ task }: Props) {
   return (
     <ItemWrapper>
+      <button type="button">
+        <IoClose size={20} />
+      </button>
       <p id="task-title">{task.title}</p>
       <LabelField>
         {task.labels.map((label) => (

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import { PiClockFill } from 'react-icons/pi';
+import { RiInfinityLine } from 'react-icons/ri';
+import styled from 'styled-components';
+
+import { hashStringToColor } from '@utils';
+
+const ItemWrapper = styled.div`
+  padding: 1rem;
+  width: 18rem;
+  min-height: 8rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: #fdfdfd;
+  border-radius: 10px;
+  box-shadow: 1px 1px 1px 2px rgba(0, 0, 0, 0.1);
+
+  #task-title {
+    word-wrap: break-word;
+  }
+
+  &:hover {
+    background-color: #ececec;
+  }
+`;
+
+const LabelField = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+`;
+
+const LabelItem = styled.div<{ color: string }>`
+  padding: 0.1rem 0.5rem;
+  border-radius: 5px;
+  color: white;
+  font-size: 0.7rem;
+  text-align: center;
+  background-color: ${(prop) => prop.color};
+`;
+
+const InfoField = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const DateField = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.7rem;
+  line-height: 110%;
+
+  .date-infinity {
+    width: 2rem;
+    display: flex;
+    justify-content: center;
+  }
+`;
+
+interface Label {
+  id: number;
+  value: string;
+}
+
+interface TaskType {
+  id: number;
+  title: string;
+  labels: Label[];
+  assignee: string;
+  order: number;
+  dateRange: null | string[];
+}
+
+interface Props {
+  task: TaskType;
+}
+
+export default function TaskItem({ task }: Props) {
+  return (
+    <ItemWrapper>
+      <p id="task-title">{task.title}</p>
+      <LabelField>
+        {task.labels.map((label) => (
+          <LabelItem key={label.id} color={hashStringToColor(label.id.toString())}>
+            {label.value}
+          </LabelItem>
+        ))}
+      </LabelField>
+      <InfoField>
+        <DateField>
+          {task.dateRange ? (
+            <>
+              <PiClockFill size={16} color="#64D4AB" />
+              <div>
+                {`${task.dateRange[0]}`}
+                <br />
+                {` ~ ${task.dateRange[1]}`}
+              </div>
+            </>
+          ) : (
+            <div className="date-infinity">
+              <RiInfinityLine size={24} />
+            </div>
+          )}
+        </DateField>
+        <div>{task.assignee}</div>
+      </InfoField>
+    </ItemWrapper>
+  );
+}

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { IoClose } from 'react-icons/io5';
+import { IoClose, IoInfinite } from 'react-icons/io5';
 import { PiClockFill } from 'react-icons/pi';
-import { RiInfinityLine } from 'react-icons/ri';
 import styled from 'styled-components';
 
 import { hashStringToColor } from '@utils';
@@ -66,6 +65,7 @@ const DateField = styled.div`
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  justify-content: center;
   font-size: 0.7rem;
   line-height: 110%;
 
@@ -121,7 +121,7 @@ export default function TaskItem({ task }: Props) {
             </>
           ) : (
             <div className="date-infinity">
-              <RiInfinityLine size={24} />
+              <IoInfinite size={24} color="#1C2A4B" />
             </div>
           )}
         </DateField>

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import Modal from '@components/Modal';
 
-type ModalType = 'none' | 'normal' | 'exitPlan' | 'addTask';
+type ModalType = 'none' | 'normal' | 'exitPlan' | 'addTask' | 'editTask';
 
 export default function useModal() {
   const [showModal, setShowModal] = useState<ModalType>('none');

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 
 import Modal from '@components/Modal';
 
+type ModalType = 'none' | 'normal' | 'exitPlan' | 'addTask';
+
 export default function useModal() {
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const openModal = () => setShowModal(true);
-  const closeModal = () => setShowModal(false);
+  const [showModal, setShowModal] = useState<ModalType>('none');
+  const openModal = (modalType: ModalType) => setShowModal(modalType);
+  const closeModal = () => setShowModal('none');
   return { Modal, showModal, openModal, closeModal };
 }

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -299,7 +299,9 @@ function Plan() {
               title={item.title!}
               onEdit={editTabInfo}
               tasks={item.tasks!}
-              onClickHandler={openModal}
+              onClickHandler={() => {
+                openModal('addTask');
+              }}
             />
           ))}
           {isAddingTab && (
@@ -313,7 +315,11 @@ function Plan() {
                 onKeyDown={handleInputKeyDown}
               />
               {/* TODO 탭 추가하다 취소하는 버튼 추가 */}
-              <TasksContainer onClickHandler={openModal} />
+              <TasksContainer
+                onClickHandler={() => {
+                  openModal('addTask');
+                }}
+              />
             </TabWrapper>
           )}
           <AddTapButton onClick={handleAddTab}>
@@ -321,9 +327,9 @@ function Plan() {
           </AddTapButton>
         </TabGroup>
       </MainContainer>
-      {showModal && (
+      {showModal === 'addTask' && (
         <Modal
-          type="addTask"
+          type={showModal}
           onClose={closeModal}
           requestAPI={() => {
             // TODO: 할 일 추가 API 입력

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -17,6 +17,7 @@ interface Label {
 }
 
 interface TaskType {
+  id: number;
   title: string;
   labels: Label[];
   assignee: string;

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -334,7 +334,7 @@ function Plan() {
           requestAPI={() => {
             // TODO: 할 일 추가 API 입력
           }}
-          members={plan?.members.map((member) => [member.name, member.id.toString()])}
+          members={plan?.members}
           allLabels={['개발도서', '코테', '이력서']}
         />
       )}

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -21,6 +21,7 @@ interface TaskType {
   title: string;
   tabId: number;
   labels: Label[];
+  assignee: string;
   assigneeId: number;
   order: number;
   dateRange: null | string[];

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -22,6 +22,7 @@ interface TaskType {
   labels: Label[];
   assignee: string;
   order: number;
+  dateRange: null | string[];
 }
 
 interface TabType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,24 @@ export interface TaskInfo {
   labels: string[];
   deadline: string;
 }
+
+export interface Label {
+  id: number;
+  value: string;
+}
+
+export interface TaskType {
+  id: number;
+  title: string;
+  labels: Label[];
+  assignee: string;
+  order: number;
+  dateRange: null | string[];
+}
+
+export interface MemberType {
+  id: number;
+  name: string;
+  imgUrl?: string;
+  isAdmin: boolean;
+}


### PR DESCRIPTION
## 📌 Description
- 레이블, 레이블 인풋 컴포넌트 분리
- 레이블 인풋 내에서 레이블이 많아질 경우, 검색창에서 focus된 DOM을 스크롤이 자동으로 따라가도록 구현
- 공통 사용 타입 정의
- 모달 버그 수정

## ⚠️ 주의사항
- `types` 폴더에 공동으로 주로 사용되는 타입을 정의해두면 좋을 것 같은데 현님 생각은 어떠신가요!
- Label 관련 API는 좀더 이야기해볼 것이 있어서 Conflict를 대비해 PR 한번 잘라서 요청했습니다!

close #47 