### PR TITLE
[#24] 탭 정렬, tasks 분류 리팩토링 및 기본적인 탭 drag&drop구현

### DIFF
--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -161,13 +161,7 @@ export function Tab({
   onDrop,
 }: TabProps) {
   return (
-    <Wrapper
-      draggable
-      onDragStart={onDragStart}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      // style={{ opacity: draggedTab === id ? 0.5 : 1 }}
-    >
+    <Wrapper draggable onDragStart={onDragStart} onDragOver={onDragOver} onDrop={onDrop}>
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
       <TasksContainer tasks={tasks} onClickHandler={onClickHandler} />
     </Wrapper>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -12,6 +12,9 @@ type TabProps = {
   onDeleteTab: () => void;
   onSaveTitle: (title: string) => void;
   onClickHandler: () => void;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
 };
 
 type TabHeaderProps = {
@@ -139,18 +142,32 @@ export function TasksContainer({ tasks, onClickHandler }: TaskContainerProps) {
   return (
     <Container>
       {tasks?.map((task) => <TaskItem key={task.id} task={task} />)}
-      {/* TODO 할일 drag&drop */}
       <AddButton type="button" className="add" onClick={onClickHandler}>
-        {/* TODO 클릭시 일정 추가(모달) */}
+        {/* TODO 클릭시 일정 추가 */}
         Add Item
       </AddButton>
     </Container>
   );
 }
 
-export function Tab({ title, tasks, onDeleteTab, onClickHandler, onSaveTitle }: TabProps) {
+export function Tab({
+  title,
+  tasks,
+  onDeleteTab,
+  onClickHandler,
+  onSaveTitle,
+  onDragStart,
+  onDragOver,
+  onDrop,
+}: TabProps) {
   return (
-    <Wrapper>
+    <Wrapper
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      // style={{ opacity: draggedTab === id ? 0.5 : 1 }}
+    >
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
       <TasksContainer tasks={tasks} onClickHandler={onClickHandler} />
     </Wrapper>

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -223,7 +223,19 @@ function Plan() {
     return <div>Loading...</div>;
   }
 
-  const sortedTabs = plan.tabOrder.map((tabId) => plan.tabs.find((tab) => tab.id === tabId)!);
+  const tabLookup: Record<number, TabType> = {};
+  plan.tabs.forEach((tab) => {
+    tabLookup[tab.id] = tab;
+  });
+  const sortedTabs = plan.tabOrder.map((tabId) => tabLookup[tabId]);
+
+  const tasksByTab: Record<number, ITask[]> = {};
+  plan.tasks.forEach((task) => {
+    if (!tasksByTab[task.tabId]) {
+      tasksByTab[task.tabId] = [];
+    }
+    tasksByTab[task.tabId].push(task);
+  });
 
   const handleStartAddingTab = () => {
     setIsAddingTab(true);
@@ -325,7 +337,7 @@ function Plan() {
               key={item.id}
               title={item.title}
               onDeleteTab={() => handleDeleteTab(item.id)}
-              tasks={plan.tasks.filter((task) => task.tabId === item.id)}
+              tasks={tasksByTab[item.id]}
               onClickHandler={() => {
                 openModal('addTask');
               }}

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -181,25 +181,26 @@ function Plan() {
     const filteredByLabelTasks =
       labels.length > 0 ? data.tasks.filter((task) => task.labels.some((label) => labels.includes(label))) : data.tasks;
 
-    // {3: id=3인 탭, 1: id=1인 탭, 2:id=2인 탭}
-    const tabIndex: Record<number, TabType> = {};
-    data.tabs.forEach((tab) => {
-      tabIndex[tab.id] = { ...tab, tasks: [] };
-    });
+    // console.log(filteredByLabelTasks);
+    // // {3: id=3인 탭, 1: id=1인 탭, 2:id=2인 탭}
+    // const tabIndex: Record<number, TabType> = {};
+    // data.tabs.forEach((tab) => {
+    //   tabIndex[tab.id] = { ...tab, tasks: [] };
+    // });
 
-    filteredByLabelTasks.forEach((task) => {
-      const tab = tabIndex[task.tabId];
-      if (tab) {
-        tab.tasks!.push(task);
-      }
-    });
+    // filteredByLabelTasks.forEach((task) => {
+    //   const tab = tabIndex[task.tabId];
+    //   if (tab) {
+    //     tab.tasks!.push(task);
+    //   }
+    // });
 
-    const arrangedTabs = data.tabOrder.map((tabId) => {
-      const tab = tabIndex[tabId];
-      return tab;
-    });
+    // const arrangedTabs = data.tabOrder.map((tabId) => {
+    //   const tab = tabIndex[tabId];
+    //   return tab;
+    // });
 
-    return { ...data, tabs: arrangedTabs };
+    return { ...data, tasks: filteredByLabelTasks };
   };
 
   useEffect(() => {
@@ -217,6 +218,12 @@ function Plan() {
 
     fetchData();
   }, [selectedLabels]);
+
+  if (!plan) {
+    return <div>Loading...</div>;
+  }
+
+  const sortedTabs = plan.tabOrder.map((tabId) => plan.tabs.find((tab) => tab.id === tabId)!);
 
   const handleStartAddingTab = () => {
     setIsAddingTab(true);
@@ -313,12 +320,12 @@ function Plan() {
           </UtilContainer>
         </TopContainer>
         <TabGroup>
-          {plan?.tabs?.map((item) => (
+          {sortedTabs.map((item) => (
             <Tab
               key={item.id}
-              title={item.title!}
+              title={item.title}
               onDeleteTab={() => handleDeleteTab(item.id)}
-              tasks={item.tasks!}
+              tasks={plan.tasks.filter((task) => task.tabId === item.id)}
               onClickHandler={() => {
                 openModal('addTask');
               }}

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -173,7 +173,7 @@ function Plan() {
   const setLabels = useSetRecoilState(labelsState);
   const [draggedTabId, setDraggedTabId] = useState<number | null>(null);
 
-  const FilterPlanTasks = (data: PlanType, labels: number[]) => {
+  const filterPlanTasks = (data: PlanType, labels: number[]) => {
     if (!data) {
       return data;
     }
@@ -191,10 +191,10 @@ function Plan() {
     const fetchData = async () => {
       try {
         const data = await getPlanInfo();
-        const FilteredPlan = FilterPlanTasks(data, selectedLabels);
-        setMembers(FilteredPlan.members);
-        setLabels(FilteredPlan.labels);
-        setPlan(FilteredPlan);
+        const filteredPlan = filterPlanTasks(data, selectedLabels);
+        setMembers(filteredPlan.members);
+        setLabels(filteredPlan.labels);
+        setPlan(filteredPlan);
       } catch (error) {
         throw new Error('플랜 정보를 가져오는데 실패했습니다.');
       }


### PR DESCRIPTION
📌 Description
- 이전에 데이터를 fetch해 오자마자 tabOrder에 따라 tabs를 배열하고 tabId별로 tasks를 분류해서 setPlan을 했었는데 가공하지 않고 바로 setPlan하도록 변경했습니다.
  - 대신 sortedTabs, tasksByTabId 라는 배열과 객체를 만들었습니다.
  - 탭 drag&drop을 할 때 tabsOrder 뿐만 아니라 tabs의 순서도 변경해줘야 하는 게 번거롭다고 생각해서 바꿨습니다. 
  - 이전에 sortTabAndFilterPlanByLabels였던 함수가 이제 필터링만 하기 때문에 filterPlanTasks로 이름을 바꿨습니다.
- 정말 기본적인 drag&drop을 구현했습니다.
  - 탭 순서 변경은 되지만 css가 전혀 되어 있지 않아요.
  - css는 내일 하려구요 css가 생각보다 복잡하네요
 
⚠️ 주의사항
- 준영님 member 필터링 구현하실 때 filterPlanTasks 함수 안에서 tasks를 필터링 해주시면 될 것 같습니다.

close #24