### PR TITLE
[#55] 탭 드래그앤드롭 로직 리팩토링

### DIFF
--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -6,16 +6,49 @@ import { ITask } from 'types';
 import Dropdown from '@components/Dropdown';
 import TaskItem from '@components/TaskItem';
 
+// interface Label {
+//   id: number;
+//   value: string;
+// }
+
+// interface TabType {
+//   id: number;
+//   title: string;
+//   tasks?: ITask[];
+// }
+
+// interface MemberType {
+//   id: number;
+//   name: string;
+//   imgUrl?: string;
+//   isAdmin: boolean;
+// }
+
+// interface PlanType {
+//   title: string;
+//   description: string;
+//   isPublic: boolean;
+//   members: MemberType[];
+//   tabOrder: number[];
+//   tabs: TabType[];
+//   labels: Label[];
+//   tasks: ITask[];
+// }
+
 type TabProps = {
+  // plan: PlanType;
+  // setPlan: Dispatch<SetStateAction<PlanType | null>>;
+  id: number;
+  index: number;
   title: string;
   tasks: ITask[];
   onDeleteTab: () => void;
   onSaveTitle: (title: string) => void;
   onClickHandler: () => void;
-  isDragging: boolean;
-  onDragStart: (e: React.DragEvent) => void;
-  onDragEnter: (e: React.DragEvent) => void;
-  onDragEnd: (e: React.DragEvent) => void;
+  // isDragging: boolean;
+  // onDragStart: (e: React.DragEvent) => void;
+  // onDragEnter: (e: React.DragEvent) => void;
+  // onDragEnd: (e: React.DragEvent) => void;
 };
 
 type TabHeaderProps = {
@@ -160,23 +193,29 @@ export function TasksContainer({ tasks, onClickHandler }: TaskContainerProps) {
 }
 
 export function Tab({
+  id,
+  index,
   title,
   tasks,
   onDeleteTab,
   onClickHandler,
-  onSaveTitle,
-  isDragging,
-  onDragStart,
-  onDragEnter,
-  onDragEnd,
-}: TabProps) {
+  onSaveTitle, // isDragging,
+  // onDragEnter,
+} // onDragStart,
+// onDragEnd,
+: TabProps) {
+  // console.log(isDragging, onDragStart, onDragEnter, onDragEnd);
+  console.log(index);
   return (
     <Wrapper
       draggable
-      onDragStart={onDragStart}
-      onDragEnter={onDragEnter}
-      onDragEnd={onDragEnd}
-      className={isDragging ? 'dragging' : ''}
+      data-index={index}
+      data-id={id}
+      className="dnd-item"
+      // onDragStart={onDragStart}
+      // onDragEnter={onDragEnter}
+      // onDragEnd={onDragEnd}
+      // className={isDragging ? 'dragging' : ''}
     >
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
       <TasksContainer tasks={tasks} onClickHandler={onClickHandler} />

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -43,8 +43,9 @@ const Wrapper = styled.li`
   transition: opacity 0.2s;
 
   &.dragging {
+    /* dragging할 때 curosr가 not-allowed인 버그가 있음 */
+    cursor: grabbing;
     opacity: 0.5;
-    /* border: 2px solid #64d4ab; */
   }
 `;
 

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/require-default-props */
+/* eslint-disable react/no-unused-prop-types */
+
 import React, { useState, useRef } from 'react';
 
 import styled from 'styled-components';
@@ -6,7 +9,7 @@ import { ITask } from 'types';
 import Dropdown from '@components/Dropdown';
 import TaskItem from '@components/TaskItem';
 
-type TabProps = {
+interface ITabProps {
   id: number;
   index: number;
   title: string;
@@ -14,22 +17,19 @@ type TabProps = {
   onDeleteTab: () => void;
   onSaveTitle: (title: string) => void;
   onClickHandler: () => void;
-};
+}
 
-type TabHeaderProps = {
+interface ITabHeaderProps {
   initialTitle: string;
   onDeleteTab: () => void;
-  // eslint-disable-next-line react/no-unused-prop-types, react/require-default-props
   onClickHandler?: () => void;
   onSaveTitle: (title: string) => void;
-};
+}
 
-type TaskContainerProps = {
-  // eslint-disable-next-line react/require-default-props
+interface ITaskContainerProps {
   tasks?: ITask[];
-  // eslint-disable-next-line react/require-default-props
   onClickHandler?: () => void;
-};
+}
 
 const Wrapper = styled.li`
   height: 100%;
@@ -91,7 +91,7 @@ const AddButton = styled.button`
   transform: translateX(-50%);
 `;
 
-function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: TabHeaderProps) {
+function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: ITabHeaderProps) {
   const tabEditOptions = [{ id: 1, label: '삭제', value: 'delete' }];
   const [title, setTitle] = useState(initialTitle);
   const [isEditing, setIsEditing] = useState(false);
@@ -137,7 +137,7 @@ function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: TabHeaderProps) {
   );
 }
 
-export function TasksContainer({ tasks, onClickHandler }: TaskContainerProps) {
+export function TasksContainer({ tasks, onClickHandler }: ITaskContainerProps) {
   return (
     <Container>
       {tasks?.map((task) => <TaskItem key={task.id} task={task} />)}
@@ -149,7 +149,7 @@ export function TasksContainer({ tasks, onClickHandler }: TaskContainerProps) {
   );
 }
 
-export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSaveTitle }: TabProps) {
+export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSaveTitle }: ITabProps) {
   return (
     <Wrapper draggable data-index={index} data-id={id} className="dnd-item">
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -12,9 +12,10 @@ type TabProps = {
   onDeleteTab: () => void;
   onSaveTitle: (title: string) => void;
   onClickHandler: () => void;
+  isDragging: boolean;
   onDragStart: (e: React.DragEvent) => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDrop: (e: React.DragEvent) => void;
+  onDragEnter: (e: React.DragEvent) => void;
+  onDragEnd: (e: React.DragEvent) => void;
 };
 
 type TabHeaderProps = {
@@ -38,6 +39,13 @@ const Wrapper = styled.li`
   flex-direction: column;
   gap: 0.5rem;
   justify-content: space-between;
+  cursor: grab;
+  transition: opacity 0.2s;
+
+  &.dragging {
+    opacity: 0.5;
+    /* border: 2px solid #64d4ab; */
+  }
 `;
 
 const Header = styled.div`
@@ -156,12 +164,19 @@ export function Tab({
   onDeleteTab,
   onClickHandler,
   onSaveTitle,
+  isDragging,
   onDragStart,
-  onDragOver,
-  onDrop,
+  onDragEnter,
+  onDragEnd,
 }: TabProps) {
   return (
-    <Wrapper draggable onDragStart={onDragStart} onDragOver={onDragOver} onDrop={onDrop}>
+    <Wrapper
+      draggable
+      onDragStart={onDragStart}
+      onDragEnter={onDragEnter}
+      onDragEnd={onDragEnd}
+      className={isDragging ? 'dragging' : ''}
+    >
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
       <TasksContainer tasks={tasks} onClickHandler={onClickHandler} />
     </Wrapper>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -6,38 +6,7 @@ import { ITask } from 'types';
 import Dropdown from '@components/Dropdown';
 import TaskItem from '@components/TaskItem';
 
-// interface Label {
-//   id: number;
-//   value: string;
-// }
-
-// interface TabType {
-//   id: number;
-//   title: string;
-//   tasks?: ITask[];
-// }
-
-// interface MemberType {
-//   id: number;
-//   name: string;
-//   imgUrl?: string;
-//   isAdmin: boolean;
-// }
-
-// interface PlanType {
-//   title: string;
-//   description: string;
-//   isPublic: boolean;
-//   members: MemberType[];
-//   tabOrder: number[];
-//   tabs: TabType[];
-//   labels: Label[];
-//   tasks: ITask[];
-// }
-
 type TabProps = {
-  // plan: PlanType;
-  // setPlan: Dispatch<SetStateAction<PlanType | null>>;
   id: number;
   index: number;
   title: string;
@@ -45,10 +14,6 @@ type TabProps = {
   onDeleteTab: () => void;
   onSaveTitle: (title: string) => void;
   onClickHandler: () => void;
-  // isDragging: boolean;
-  // onDragStart: (e: React.DragEvent) => void;
-  // onDragEnter: (e: React.DragEvent) => void;
-  // onDragEnd: (e: React.DragEvent) => void;
 };
 
 type TabHeaderProps = {
@@ -72,14 +37,6 @@ const Wrapper = styled.li`
   flex-direction: column;
   gap: 0.5rem;
   justify-content: space-between;
-  cursor: grab;
-  transition: opacity 0.2s;
-
-  &.dragging {
-    /* dragging할 때 curosr가 not-allowed인 버그가 있음 */
-    cursor: grabbing;
-    opacity: 0.5;
-  }
 `;
 
 const Header = styled.div`
@@ -192,31 +149,9 @@ export function TasksContainer({ tasks, onClickHandler }: TaskContainerProps) {
   );
 }
 
-export function Tab({
-  id,
-  index,
-  title,
-  tasks,
-  onDeleteTab,
-  onClickHandler,
-  onSaveTitle, // isDragging,
-  // onDragEnter,
-} // onDragStart,
-// onDragEnd,
-: TabProps) {
-  // console.log(isDragging, onDragStart, onDragEnter, onDragEnd);
-  console.log(index);
+export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSaveTitle }: TabProps) {
   return (
-    <Wrapper
-      draggable
-      data-index={index}
-      data-id={id}
-      className="dnd-item"
-      // onDragStart={onDragStart}
-      // onDragEnter={onDragEnter}
-      // onDragEnd={onDragEnd}
-      // className={isDragging ? 'dragging' : ''}
-    >
+    <Wrapper draggable data-index={index} data-id={id} className="dnd-item">
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
       <TasksContainer tasks={tasks} onClickHandler={onClickHandler} />
     </Wrapper>

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -283,16 +283,13 @@ function Plan() {
 
   const handleDragTabStart = (e: React.DragEvent, tabId: number) => {
     setDraggedTabId(tabId);
-    e.dataTransfer.setData('text/plain', tabId.toString());
+    // e.dataTransfer.setData('text/plain', tabId.toString());
+    // draggable 속정을 주면 요소가 반투명하게 따라오는 걸 없애기 위해 빈 이미지 생성함
+    // const img = new Image();
+    // e.dataTransfer.setDragImage(img, 0, 0);
   };
 
-  const handleDragTabOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-
-  const handleDropTab = (e: React.DragEvent, targetTabId: number) => {
-    e.preventDefault();
-
+  const handleDragTabEnter = (e: React.DragEvent, targetTabId: number) => {
     if (draggedTabId === null) return;
 
     const newTabOrder = [...plan.tabOrder];
@@ -310,6 +307,9 @@ function Plan() {
         return { ...prev, tabOrder: newTabOrder };
       });
     }
+  };
+
+  const handleDragTabEnd = () => {
     setDraggedTabId(null);
   };
 
@@ -358,9 +358,10 @@ function Plan() {
                 openModal('addTask');
               }}
               onSaveTitle={handleSaveTabTitle}
+              isDragging={draggedTabId === item.id}
               onDragStart={(e: React.DragEvent) => handleDragTabStart(e, item.id)}
-              onDragOver={handleDragTabOver}
-              onDrop={(e: React.DragEvent) => handleDropTab(e, item.id)}
+              onDragEnter={(e: React.DragEvent) => handleDragTabEnter(e, item.id)}
+              onDragEnd={handleDragTabEnd}
             />
           ))}
           {isAddingTab && (

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -13,34 +13,34 @@ import MemberFilter from '@components/MemberFilter';
 import { Tab, TasksContainer } from '@components/Tab';
 import useModal from '@hooks/useModal';
 import { labelsState, membersState } from '@recoil/atoms';
-import registDND, { TDropEvent } from '@utils/drag';
+import registDND, { IDropEvent } from '@utils/drag';
 
-interface Label {
+interface ILabel {
   id: number;
   value: string;
 }
 
-interface TabType {
+interface ITab {
   id: number;
   title: string;
   tasks?: ITask[];
 }
 
-interface MemberType {
+interface IMember {
   id: number;
   name: string;
   imgUrl?: string;
   isAdmin: boolean;
 }
 
-interface PlanType {
+interface IPlan {
   title: string;
   description: string;
   isPublic: boolean;
-  members: MemberType[];
+  members: IMember[];
   tabOrder: number[];
-  tabs: TabType[];
-  labels: Label[];
+  tabs: ITab[];
+  labels: ILabel[];
   tasks: ITask[];
 }
 
@@ -163,7 +163,7 @@ const planNameList = [
 ];
 
 function Plan() {
-  const [plan, setPlan] = useState<PlanType | null>(null);
+  const [plan, setPlan] = useState<IPlan | null>(null);
   const [selectedPlanName, setSelectedPlanName] = useState<string>('My Plan');
   const [newTabTitle, setNewTabTitle] = useState<string>('');
   const [isAddingTab, setIsAddingTab] = useState<boolean>(false);
@@ -173,7 +173,7 @@ function Plan() {
   const setMembers = useSetRecoilState(membersState);
   const setLabels = useSetRecoilState(labelsState);
 
-  const filterPlanTasks = (data: PlanType, labels: number[]) => {
+  const filterPlanTasks = (data: IPlan, labels: number[]) => {
     if (!data) {
       return data;
     }
@@ -203,7 +203,7 @@ function Plan() {
     fetchData();
   }, [selectedLabels]);
 
-  const handleDrag = ({ source, destination }: TDropEvent) => {
+  const handleDrag = ({ source, destination }: IDropEvent) => {
     if (!destination) return;
 
     if (!plan) return;
@@ -231,7 +231,7 @@ function Plan() {
     return <div>Loading...</div>;
   }
 
-  const tabById: Record<number, TabType> = {};
+  const tabById: Record<number, ITab> = {};
   plan.tabs.forEach((tab) => {
     tabById[tab.id] = tab;
   });
@@ -258,7 +258,7 @@ function Plan() {
     if (newTabTitle.trim() === '') {
       setIsAddingTab(false);
     } else {
-      const newTab: TabType = {
+      const newTab: ITab = {
         id: (plan?.tabs.length || 0) + 1,
         title: newTabTitle,
       };

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -13,7 +13,7 @@ import MemberFilter from '@components/MemberFilter';
 import { Tab, TasksContainer } from '@components/Tab';
 import useModal from '@hooks/useModal';
 import { labelsState, membersState } from '@recoil/atoms';
-import registDND from '@utils/drag';
+import registDND, { TDropEvent } from '@utils/drag';
 
 interface Label {
   id: number;
@@ -44,15 +44,6 @@ interface PlanType {
   tasks: ITask[];
 }
 
-type DropItem = {
-  id: number;
-  index: number;
-};
-
-type DropEvent = {
-  source: DropItem;
-  destination?: DropItem;
-};
 const Wrapper = styled.main`
   width: 100vw;
   min-height: 100vh;
@@ -181,7 +172,6 @@ function Plan() {
   const [selectedLabels, setSelectedLabel] = useState<number[]>([]);
   const setMembers = useSetRecoilState(membersState);
   const setLabels = useSetRecoilState(labelsState);
-  // const [draggedTabId, setDraggedTabId] = useState<number | null>(null);
 
   const filterPlanTasks = (data: PlanType, labels: number[]) => {
     if (!data) {
@@ -213,15 +203,11 @@ function Plan() {
     fetchData();
   }, [selectedLabels]);
 
-  const handleDrag = ({ source, destination }: DropEvent) => {
+  const handleDrag = ({ source, destination }: TDropEvent) => {
     if (!destination) return;
 
     if (!plan) return;
     const newTabOrder = [...plan.tabOrder];
-    // const scourceKey = source.droppableId;
-    // const destinationKey = destination.droppableId;
-    console.log(source, destination);
-    console.log(newTabOrder);
     const draggedTabIndex = newTabOrder.indexOf(source.id);
     const targetTabIndex = newTabOrder.indexOf(destination.id);
     newTabOrder.splice(draggedTabIndex, 1);
@@ -237,7 +223,6 @@ function Plan() {
   };
 
   useEffect(() => {
-    console.log('hi');
     const clear = registDND(handleDrag);
     return () => clear();
   }, [plan]);
@@ -320,50 +305,8 @@ function Plan() {
     return title;
   };
 
-  // const handleDragTabStart = (e: React.DragEvent, tabId: number) => {
-  //   setDraggedTabId(tabId);
-  //   // e.dataTransfer.setData('text/plain', tabId.toString());
-  //   // draggable 속정을 주면 요소가 반투명하게 따라오는 걸 없애기 위해 빈 이미지 생성함
-  //   // const img = new Image();
-  //   // e.dataTransfer.setDragImage(img, 0, 0);
-  // };
-
-  // const handleDragTabEnter = (e: React.DragEvent, targetTabId: number) => {
-  //   if (draggedTabId === null) return;
-
-  //   const newTabOrder = [...plan.tabOrder];
-  //   const draggedTabIndex = newTabOrder.indexOf(draggedTabId);
-  //   const targetTabIndex = newTabOrder.indexOf(targetTabId);
-
-  //   newTabOrder.splice(draggedTabIndex, 1);
-  //   newTabOrder.splice(targetTabIndex, 0, draggedTabId);
-
-  //   // TODO: 서버에 탭 순서 변경 요청
-  //   if (plan) {
-  //     setPlan((prev) => {
-  //       if (!prev) return prev;
-
-  //       return { ...prev, tabOrder: newTabOrder };
-  //     });
-  //   }
-  // };
-
-  // const handleDragTabEnd = () => {
-  //   setDraggedTabId(null);
-  // };
-
-  // type DropItem = {
-  //   droppableId: string;
-  //   index: number;
-  // };
-
-  // type DropEvent = {
-  //   source: DropItem;
-  //   destination?: DropItem;
-  // };
-  console.log(sortedTabs);
   return (
-    <Wrapper data-droppable-id={1}>
+    <Wrapper>
       <SideContainer>
         <PlanCategory>
           {planNameList.map((item) => (
@@ -396,11 +339,9 @@ function Plan() {
             </div>
           </UtilContainer>
         </TopContainer>
-        <TabGroup>
+        <TabGroup data-droppable-id={1} className="droppable">
           {sortedTabs.map((item, index) => (
             <Tab
-              // plan={plan}
-              // setPlan={setPlan}
               id={item.id}
               key={item.id}
               index={index}
@@ -411,10 +352,6 @@ function Plan() {
                 openModal('addTask');
               }}
               onSaveTitle={handleSaveTabTitle}
-              // isDragging={draggedTabId === item.id}
-              // onDragStart={(e: React.DragEvent) => handleDragTabStart(e, item.id)}
-              // onDragEnter={(e: React.DragEvent) => handleDragTabEnter(e, item.id)}
-              // onDragEnd={handleDragTabEnd}
             />
           ))}
           {isAddingTab && (

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -263,11 +263,12 @@ function Plan() {
         title: newTabTitle,
       };
 
+      // 서버에 탭 추가 요청
       setPlan((prev) => {
         if (!prev) {
           return prev;
         }
-        return { ...plan!, tabs: [...plan!.tabs, newTab] };
+        return { ...plan, tabs: [...plan.tabs, newTab], tabOrder: [...plan.tabOrder, newTab.id] };
       });
 
       setIsAddingTab(false);

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -213,7 +213,7 @@ function Plan() {
     newTabOrder.splice(draggedTabIndex, 1);
     newTabOrder.splice(targetTabIndex, 0, source.id);
 
-    console.log(source.id, destination.id);
+    // console.log(source.id, destination.id);
 
     setPlan((prev) => {
       if (!prev) return prev;

--- a/src/utils/drag.ts
+++ b/src/utils/drag.ts
@@ -1,14 +1,14 @@
 /* eslint-disable no-param-reassign */
 
-export type TDropItem = {
+export interface IDropItem {
   id: number;
   index: number;
-};
+}
 
-export type TDropEvent = {
-  source: TDropItem;
-  destination?: TDropItem;
-};
+export interface IDropEvent {
+  source: IDropItem;
+  destination?: IDropItem;
+}
 
 const startEventName = 'mousedown';
 const moveEventName = 'mousemove';
@@ -22,7 +22,7 @@ const getDelta = (startEvent: MouseEvent, moveEvent: MouseEvent) => {
   };
 };
 
-export default function registDND(onDrop: (event: TDropEvent) => void) {
+export default function registDND(onDrop: (event: IDropEvent) => void) {
   const handleStart = (startEvent: MouseEvent) => {
     // 드래그할 탭 요소
     const item = (startEvent.target as HTMLElement).closest<HTMLElement>('.dnd-item');

--- a/src/utils/drag.ts
+++ b/src/utils/drag.ts
@@ -15,34 +15,31 @@ const moveEventName = 'mousemove';
 const endEventName = 'mouseup';
 
 const getDelta = (startEvent: MouseEvent, moveEvent: MouseEvent) => {
-  const se = startEvent;
-  const me = moveEvent;
-
   return {
-    deltaX: me.pageX - se.pageX,
-    deltaY: me.pageY - se.pageY,
+    deltaX: moveEvent.pageX - startEvent.pageX,
+    deltaY: moveEvent.pageY - startEvent.pageY,
   };
 };
 
 export default function registDND(onDrop: (event: TDropEvent) => void) {
-  const startHandler = (startEvent: MouseEvent) => {
+  const handleStart = (startEvent: MouseEvent) => {
     const item = (startEvent.target as HTMLElement).closest<HTMLElement>('.dnd-item');
 
     if (!item || item.classList.contains('moving')) {
       return;
     }
 
-    // 여기가 드래그할 때 타겟아이템 관련 id, index다.
     let destination: HTMLElement | null | undefined;
     let destinationItem: HTMLElement | null | undefined;
     let destinationIndex: number;
     let destinationId: number;
 
-    const source = item.closest<HTMLElement>('[data-droppable-id]'); // tab을 갖고 있는 ul
+    // tab을 갖고 있는 ul
+    const source = item.closest<HTMLElement>('[data-droppable-id]');
     if (!source) throw Error('Need `data-droppable-id` at dnd-item parent');
 
     let movingItem: HTMLElement;
-    // 사실 필요없다.
+
     const sourceIndex = Number(item.dataset.index);
     const sourceId = Number(item.dataset.id);
 
@@ -63,7 +60,7 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
     ghostItem.style.transform = 'scale(1.05)';
     ghostItem.style.transition = 'transform 200ms ease, opacity 200ms ease, boxShadow 200ms ease';
 
-    // 사실 여기도 필요 없을 듯
+    // placeholder 아이템이 들어갈 자리를 만들어준다.
     item.classList.add('placeholder');
     item.style.cursor = 'grabbing';
 
@@ -182,7 +179,7 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
       }, 200);
     };
 
-    const endHandler = () => {
+    const handleEnd = () => {
       const sourceItem = movingItem ?? item;
       item.classList.remove('placeholder');
       movingItem?.classList.remove('placeholder');
@@ -195,7 +192,6 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
       ghostItem.style.top = `${elementRect.top}px`;
       ghostItem.style.opacity = '1';
       ghostItem.style.transform = 'none';
-      ghostItem.style.borderWidth = '0px';
       ghostItem.style.boxShadow = '0 1px 3px rgba(0, 0, 0, 0.15)';
       ghostItem.style.transition = 'all 200ms ease';
 
@@ -235,9 +231,9 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
     };
 
     document.addEventListener(moveEventName, moveHandler, { passive: false });
-    document.addEventListener(endEventName, endHandler, { once: true });
+    document.addEventListener(endEventName, handleEnd, { once: true });
   };
 
-  document.addEventListener(startEventName, startHandler);
-  return () => document.removeEventListener(startEventName, startHandler);
+  document.addEventListener(startEventName, handleStart);
+  return () => document.removeEventListener(startEventName, handleStart);
 }

--- a/src/utils/drag.ts
+++ b/src/utils/drag.ts
@@ -1,0 +1,273 @@
+/* eslint-disable no-param-reassign */
+
+const startEventName = 'mousedown';
+const moveEventName = 'mousemove';
+const endEventName = 'mouseup';
+
+const getDelta = (startEvent: MouseEvent, moveEvent: MouseEvent) => {
+  const se = startEvent;
+  const me = moveEvent;
+
+  return {
+    deltaX: me.pageX - se.pageX,
+    deltaY: me.pageY - se.pageY,
+  };
+};
+
+export type DropItem = {
+  //   droppableId: string;
+  id: number;
+  index: number;
+};
+
+export type DropEvent = {
+  source: DropItem;
+  destination?: DropItem;
+};
+
+export default function registDND(onDrop: (event: DropEvent) => void) {
+  const startHandler = (startEvent: MouseEvent) => {
+    const item = (startEvent.target as HTMLElement).closest<HTMLElement>('.dnd-item');
+
+    if (!item || item.classList.contains('moving')) {
+      return;
+    }
+
+    // 여기가 드래그할 때 타겟아이템 관련 id, index다.
+    let destination: HTMLElement | null | undefined;
+    let destinationItem: HTMLElement | null | undefined;
+    let destinationIndex: number;
+    let destinationDroppableId: string;
+    let destinationId: number;
+
+    const source = item.closest<HTMLElement>('[data-droppable-id]'); // tab을 갖고 있는 ul
+    if (!source) throw Error('Need `data-droppable-id` at dnd-item parent');
+
+    let movingItem: HTMLElement;
+    // 사실 필요없다.
+    const sourceIndex = Number(item.dataset.index);
+    const sourceId = Number(item.dataset.id);
+    const sourceDroppableId = source.dataset.droppableId!;
+
+    const itemRect = item.getBoundingClientRect();
+
+    // tab이랑 똑같이 생긴애 하나 만든다.
+    const ghostItem = item.cloneNode(true) as HTMLElement;
+    ghostItem.classList.add('ghost');
+    ghostItem.style.position = 'fixed';
+    ghostItem.style.top = `${itemRect.top}px`;
+    ghostItem.style.left = `${itemRect.left}px`;
+    ghostItem.style.width = `${itemRect.width}px`;
+    ghostItem.style.height = `${itemRect.height}px`;
+    ghostItem.style.pointerEvents = 'none';
+
+    ghostItem.style.opacity = '0.95';
+    ghostItem.style.boxShadow = '0 30px 60px rgba(0, 0, 0, .2)';
+    ghostItem.style.transform = 'scale(1.05)';
+    ghostItem.style.transition = 'transform 200ms ease, opacity 200ms ease, boxShadow 200ms ease';
+
+    // 사실 여기도 필요 없을 듯
+    item.classList.add('placeholder');
+    item.style.cursor = 'grabbing';
+
+    document.body.style.cursor = 'grabbing';
+    document.body.appendChild(ghostItem);
+
+    // 고스트가 아닌 dnd-item에 item에 대해서
+    document.querySelectorAll<HTMLElement>('.dnd-item:not(.ghost)').forEach((el) => {
+      el.style.transition = 'all 200ms ease';
+    });
+
+    const moveHandler = (moveEvent: MouseEvent) => {
+      moveEvent.preventDefault();
+
+      const { deltaX, deltaY } = getDelta(startEvent, moveEvent);
+      ghostItem.style.top = `${itemRect.top + deltaY}px`;
+      ghostItem.style.left = `${itemRect.left + deltaX}px`;
+
+      const ghostItemRect = ghostItem.getBoundingClientRect();
+
+      const pointTarget = document.elementFromPoint(
+        ghostItemRect.left + ghostItemRect.width / 2,
+        ghostItemRect.top + ghostItemRect.height / 2,
+      );
+
+      console.log('point', pointTarget);
+      const currentDestinationItem = pointTarget?.closest<HTMLElement>('.dnd-item');
+      const currentDestination = pointTarget?.closest<HTMLElement>('[data-droppable-id]');
+      const currentDestinationDroppableId = currentDestination?.dataset.droppableId;
+      const currentDestinationIndex = Number(currentDestinationItem?.dataset.index);
+      const currentDestinationId = Number(currentDestinationItem?.dataset.id);
+
+      console.log('currentDestinationId', currentDestinationId, currentDestinationIndex, currentDestinationItem);
+
+      const currentSourceItem = movingItem ?? item;
+      const currentSourceIndex = Number(currentSourceItem.dataset.index);
+      const currentSourceId = Number(currentSourceItem.dataset.id);
+      const currentSource = currentSourceItem.closest<HTMLElement>('[data-droppable-id]')!;
+      const currentSourceDroppableId = currentSource.dataset.droppableId;
+
+      console.log('currentSourceId', currentSourceId);
+
+      if (
+        currentDestinationItem?.isSameNode(currentSourceItem) ||
+        currentDestinationItem?.classList.contains('moving')
+      ) {
+        return;
+      }
+
+      if (
+        currentDestination &&
+        currentDestinationDroppableId &&
+        currentDestinationDroppableId !== currentSourceDroppableId
+      ) {
+        if (!movingItem) {
+          movingItem = item.cloneNode(true) as HTMLElement;
+          item.classList.remove('dnd-item');
+          item.style.display = 'none';
+        }
+
+        currentDestination.appendChild(movingItem);
+        destination = currentDestination;
+        destinationDroppableId = currentDestinationDroppableId;
+        destinationIndex = currentDestination.querySelectorAll('.dnd-item').length - 1;
+
+        currentDestination.querySelectorAll<HTMLElement>('.dnd-item').forEach((v, i) => {
+          v.dataset.index = `${i}`;
+          v.style.transform = '';
+          v.classList.remove('moved');
+        });
+        currentSource.querySelectorAll<HTMLElement>('.dnd-item').forEach((v, i) => {
+          v.dataset.index = `${i}`;
+          v.style.transform = '';
+          v.classList.remove('moved');
+        });
+      }
+
+      console.log(
+        `'${currentSourceDroppableId}': ${currentSourceIndex} -> '${currentDestinationDroppableId}': ${currentDestinationIndex}`,
+      );
+
+      if (!currentDestinationItem) {
+        return;
+      }
+
+      const ITEM_MARGIN = 24;
+      const distance = itemRect.width + ITEM_MARGIN;
+
+      console.log(itemRect);
+
+      destinationItem = currentDestinationItem;
+      destination = currentDestinationItem.closest<HTMLElement>('[data-droppable-id]');
+      destinationDroppableId = `${destination?.dataset.droppableId}`;
+      destinationId = Number(destinationItem.dataset.id);
+
+      console.log('destinationItem', destinationItem, destinationId);
+
+      const isForward = currentSourceIndex < currentDestinationIndex;
+      const isDestinationMoved = destinationItem.classList.contains('moved');
+      let indexDiff = currentDestinationIndex - currentSourceIndex;
+      if (isDestinationMoved) {
+        indexDiff += isForward ? -1 : 1;
+      }
+      destinationIndex = currentSourceIndex + indexDiff;
+
+      //   드래그 할 때 이동
+      const transX = indexDiff * distance;
+      console.log('isForward', isForward, 'transX', transX);
+      currentSourceItem.style.transform = `translate3d(${transX}px, 0, 0)`;
+
+      let target = currentDestinationItem;
+      while (target && target.classList.contains('dnd-item') && !target.classList.contains('placeholder')) {
+        console.log('플레이스홀더');
+        if (isDestinationMoved) {
+          target.style.transform = '';
+          target.classList.remove('moved');
+          target = (isForward ? target.nextElementSibling : target.previousElementSibling) as HTMLElement;
+        } else {
+          console.log('밑으로 간다');
+          target.style.transform = `translate3d(${isForward ? -distance : distance}px, 0 , 0)`;
+          target.classList.add('moved');
+          target = (isForward ? target.previousElementSibling : target.nextElementSibling) as HTMLElement;
+        }
+      }
+
+      currentDestinationItem.classList.add('moving');
+      currentDestinationItem.addEventListener(
+        'transitionend',
+        () => {
+          currentDestinationItem?.classList.remove('moving');
+        },
+        { once: true },
+      );
+      setTimeout(() => {
+        currentDestinationItem?.classList.remove('moving');
+      }, 200);
+    };
+
+    const endHandler = () => {
+      const sourceItem = movingItem ?? item;
+      item.classList.remove('placeholder');
+      movingItem?.classList.remove('placeholder');
+
+      document.body.removeAttribute('style');
+      //   clearDroppableShadow();
+
+      const elementRect = sourceItem.getBoundingClientRect();
+      ghostItem.classList.add('moving');
+      ghostItem.style.left = `${elementRect.left}px`;
+      ghostItem.style.top = `${elementRect.top}px`;
+      ghostItem.style.opacity = '1';
+      ghostItem.style.transform = 'none';
+      ghostItem.style.borderWidth = '0px';
+      ghostItem.style.boxShadow = '0 1px 3px rgba(0, 0, 0, 0.15)';
+      ghostItem.style.transition = 'all 200ms ease';
+
+      ghostItem.addEventListener(
+        'transitionend',
+        () => {
+          setTimeout(() => {
+            document.querySelectorAll<HTMLElement>('.dnd-item').forEach((el) => {
+              el.removeAttribute('style');
+              el.classList.remove('moving', 'moved');
+            });
+
+            item.classList.add('dnd-item');
+            item.removeAttribute('style');
+            movingItem?.remove();
+          }, 0);
+
+          ghostItem.remove();
+
+          console.log(
+            `result >> '${sourceDroppableId}': ${sourceIndex} -> '${destinationDroppableId}': ${destinationIndex}`,
+          );
+
+          onDrop({
+            source: {
+              //   droppableId: sourceDroppableId,
+              id: sourceId,
+              index: sourceIndex,
+            },
+            destination: destination
+              ? {
+                  //   droppableId: destinationDroppableId,
+                  id: destinationId, // 타겟 탭 id가 와야함
+                  index: destinationIndex,
+                }
+              : undefined,
+          });
+        },
+        { once: true },
+      );
+
+      document.removeEventListener(moveEventName, moveHandler);
+    };
+
+    document.addEventListener(moveEventName, moveHandler, { passive: false });
+    document.addEventListener(endEventName, endHandler, { once: true });
+  };
+
+  document.addEventListener(startEventName, startHandler);
+  return () => document.removeEventListener(startEventName, startHandler);
+}

--- a/src/utils/drag.ts
+++ b/src/utils/drag.ts
@@ -14,6 +14,7 @@ const startEventName = 'mousedown';
 const moveEventName = 'mousemove';
 const endEventName = 'mouseup';
 
+// x, y 방향 이동 거리 반환하는 함수
 const getDelta = (startEvent: MouseEvent, moveEvent: MouseEvent) => {
   return {
     deltaX: moveEvent.pageX - startEvent.pageX,
@@ -23,29 +24,36 @@ const getDelta = (startEvent: MouseEvent, moveEvent: MouseEvent) => {
 
 export default function registDND(onDrop: (event: TDropEvent) => void) {
   const handleStart = (startEvent: MouseEvent) => {
+    // 드래그할 탭 요소
     const item = (startEvent.target as HTMLElement).closest<HTMLElement>('.dnd-item');
 
-    if (!item || item.classList.contains('moving')) {
-      return;
-    }
+    if (!item || item.classList.contains('moving')) return;
 
+    // 탭을 드래그해서 이동시킬 목표지점
+    // (EX) tabOrder=[2, 1, 3]이고 id=2인 탭을 id=3인 탭으로 옮기고 싶을 때
+    // id=3인 탭이 속한 부모 요소
     let destination: HTMLElement | null | undefined;
+    // id=3인 탭 요소
     let destinationItem: HTMLElement | null | undefined;
+    // id=3인 탭의 index는 2
     let destinationIndex: number;
+    // id=3인 탭의 id는 3
     let destinationId: number;
 
-    // tab을 갖고 있는 ul
+    // 드래그되는 탭 관련
+    // id=2인 탭이 속한 부모 요소
     const source = item.closest<HTMLElement>('[data-droppable-id]');
-    if (!source) throw Error('Need `data-droppable-id` at dnd-item parent');
+    // id=2인 탭의 index는 0
+    const sourceIndex = Number(item.dataset.index);
+    // id=2인 탭의 id는 2
+    const sourceId = Number(item.dataset.id);
+    if (!source) throw Error('dnd-item의 부모 요소에는 data-droppable-id가 주어져야 합니다.');
 
     let movingItem: HTMLElement;
 
-    const sourceIndex = Number(item.dataset.index);
-    const sourceId = Number(item.dataset.id);
-
     const itemRect = item.getBoundingClientRect();
 
-    // tab이랑 똑같이 생긴 ghost 요소를 만든다.
+    // tab이랑 똑같이 생긴 ghost 탭 요소 생성
     const ghostItem = item.cloneNode(true) as HTMLElement;
     ghostItem.classList.add('ghost');
     ghostItem.style.position = 'fixed';
@@ -57,22 +65,21 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
 
     ghostItem.style.opacity = '0.95';
     ghostItem.style.boxShadow = '0 30px 60px rgba(0, 0, 0, .2)';
-    ghostItem.style.transform = 'scale(1.05)';
     ghostItem.style.transition = 'transform 200ms ease, opacity 200ms ease, boxShadow 200ms ease';
 
     // placeholder 아이템이 들어갈 자리를 만들어준다.
-    item.classList.add('placeholder');
     item.style.cursor = 'grabbing';
+    item.classList.add('placeholder');
 
     document.body.style.cursor = 'grabbing';
     document.body.appendChild(ghostItem);
 
-    // 고스트가 아닌 dnd-item에 item에 대해서
+    // ghost가 아닌 dnd-item탭 요소에 대해서
     document.querySelectorAll<HTMLElement>('.dnd-item:not(.ghost)').forEach((el) => {
       el.style.transition = 'all 200ms ease';
     });
 
-    const moveHandler = (moveEvent: MouseEvent) => {
+    const handleMove = (moveEvent: MouseEvent) => {
       moveEvent.preventDefault();
 
       const { deltaX, deltaY } = getDelta(startEvent, moveEvent);
@@ -81,27 +88,30 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
 
       const ghostItemRect = ghostItem.getBoundingClientRect();
 
+      // pointTarget : ghostItemRect 객체의 중앙 좌표에 위치한 DOM 요소
       const pointTarget = document.elementFromPoint(
         ghostItemRect.left + ghostItemRect.width / 2,
         ghostItemRect.top + ghostItemRect.height / 2,
       );
 
+      // 현재 목표지점 탭
+      // pointTarget으로부터 가장 가까운 className이 "dnd-item"인 탭이 목표지점 탭이 됨
       const currentDestinationItem = pointTarget?.closest<HTMLElement>('.dnd-item');
       const currentDestination = pointTarget?.closest<HTMLElement>('[data-droppable-id]');
       const currentDestinationDroppableId = currentDestination?.dataset.droppableId;
       const currentDestinationIndex = Number(currentDestinationItem?.dataset.index);
 
-      const currentSourceItem = movingItem ?? item;
-      const currentSourceIndex = Number(currentSourceItem.dataset.index);
+      // 현재 드래그되는 탭
+      const currentSourceItem = movingItem || item;
       const currentSource = currentSourceItem.closest<HTMLElement>('[data-droppable-id]')!;
       const currentSourceDroppableId = currentSource.dataset.droppableId;
+      const currentSourceIndex = Number(currentSourceItem.dataset.index);
 
-      if (
-        currentDestinationItem?.isSameNode(currentSourceItem) ||
-        currentDestinationItem?.classList.contains('moving')
-      ) {
+      // 목표지점 탭이 없는 경우 return
+      if (!currentDestinationItem) return;
+      // 드래그되는 탭과 목표지점 탭이 같은 경우 return
+      if (currentDestinationItem?.isSameNode(currentSourceItem) || currentDestinationItem?.classList.contains('moving'))
         return;
-      }
 
       if (
         currentDestination &&
@@ -118,22 +128,19 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
         destination = currentDestination;
         destinationIndex = currentDestination.querySelectorAll('.dnd-item').length - 1;
 
-        currentDestination.querySelectorAll<HTMLElement>('.dnd-item').forEach((v, i) => {
-          v.dataset.index = `${i}`;
-          v.style.transform = '';
-          v.classList.remove('moved');
+        currentDestination.querySelectorAll<HTMLElement>('.dnd-item').forEach((el, idx) => {
+          el.dataset.index = `${idx}`;
+          el.style.transform = '';
+          el.classList.remove('moved');
         });
-        currentSource.querySelectorAll<HTMLElement>('.dnd-item').forEach((v, i) => {
-          v.dataset.index = `${i}`;
-          v.style.transform = '';
-          v.classList.remove('moved');
+        currentSource.querySelectorAll<HTMLElement>('.dnd-item').forEach((el, idx) => {
+          el.dataset.index = `${idx}`;
+          el.style.transform = '';
+          el.classList.remove('moved');
         });
       }
 
-      if (!currentDestinationItem) {
-        return;
-      }
-
+      // 탭 마진 값
       const TAB_MARGIN = 24;
       const distance = itemRect.width + TAB_MARGIN;
 
@@ -141,7 +148,10 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
       destination = currentDestinationItem.closest<HTMLElement>('[data-droppable-id]');
       destinationId = Number(destinationItem.dataset.id);
 
+      // 드래그하는 방향 (앞: index가 0 => 1)
+      // bug: 드래그하다가 방향을 바꾸는 경우 isForward를 제대로 판단할 수 없음
       const isForward = currentSourceIndex < currentDestinationIndex;
+      // console.log(isForward);
       const isDestinationMoved = destinationItem.classList.contains('moved');
       let indexDiff = currentDestinationIndex - currentSourceIndex;
       if (isDestinationMoved) {
@@ -149,9 +159,9 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
       }
       destinationIndex = currentSourceIndex + indexDiff;
 
-      //   드래그 할 때 이동
+      // 드래그 할 때 움직일 거리
       const transX = indexDiff * distance;
-      currentSourceItem.style.transform = `translate3d(${transX}px, 0, 0)`;
+      currentSourceItem.style.transform = `translate(${transX}px, 0)`;
 
       let target = currentDestinationItem;
       while (target && target.classList.contains('dnd-item') && !target.classList.contains('placeholder')) {
@@ -160,7 +170,7 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
           target.classList.remove('moved');
           target = (isForward ? target.nextElementSibling : target.previousElementSibling) as HTMLElement;
         } else {
-          target.style.transform = `translate3d(${isForward ? -distance : distance}px, 0 , 0)`;
+          target.style.transform = `translate(${isForward ? -distance : distance}px, 0)`;
           target.classList.add('moved');
           target = (isForward ? target.previousElementSibling : target.nextElementSibling) as HTMLElement;
         }
@@ -172,7 +182,7 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
         () => {
           currentDestinationItem?.classList.remove('moving');
         },
-        { once: true },
+        { once: true }, // 이벤트가 한 번만 일어나도록하는 옵션
       );
       setTimeout(() => {
         currentDestinationItem?.classList.remove('moving');
@@ -180,7 +190,7 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
     };
 
     const handleEnd = () => {
-      const sourceItem = movingItem ?? item;
+      const sourceItem = movingItem || item;
       item.classList.remove('placeholder');
       movingItem?.classList.remove('placeholder');
 
@@ -211,6 +221,7 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
 
           ghostItem.remove();
 
+          // 콜백으로 받은 onDrop 함수 실행
           onDrop({
             source: {
               id: sourceId,
@@ -218,7 +229,7 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
             },
             destination: destination
               ? {
-                  id: destinationId, // 타겟 탭 id가 와야함
+                  id: destinationId,
                   index: destinationIndex,
                 }
               : undefined,
@@ -227,10 +238,10 @@ export default function registDND(onDrop: (event: TDropEvent) => void) {
         { once: true },
       );
 
-      document.removeEventListener(moveEventName, moveHandler);
+      document.removeEventListener(moveEventName, handleMove);
     };
 
-    document.addEventListener(moveEventName, moveHandler, { passive: false });
+    document.addEventListener(moveEventName, handleMove);
     document.addEventListener(endEventName, handleEnd, { once: true });
   };
 


### PR DESCRIPTION
📌 Description
- util/drag.ts 파일에 드래그앤드롭 로직을 작성했습니다.
- drag 이벤트가 아닌 mouse 이벤트를 사용하고 dom을 조작합니다. 
- 탭을 클릭하면 ghost 탭이 생성됩니다.
- ghost 탭이 다른 탭의 반 이상 넘어가면 위치를 이동시킵니다.

⚠️ 주의사항
- 탭 안에 모든 것을 누를 때 드래그앤드롭이 시작됩니다. 
  - 탭 안에 있는 삭제 버튼, 할일 아이템 등등
  - 지라는 할일 드래그앤드롭과 구분하고자? 탭의 헤더 부분을 클릭했을 때만 드래그앤드롭이 시작되더라구요(수정이 필요해요)
- 탭을 드래그 하는 도중 드래그 방향을 바꾸면 위치가 제대로 변경되지 않는 버그가 있습니다.
  - 원인: 드래그하는 방향(코드상 isForward)에 따라 탭을 위치 시킬 목표 지점 탭을 정합니다. 이 값이 드래그를 시작할 때 index를 기반으로 정해져서 드래그 중 방향이 변경돼도 isForward가 변경되지 않아 생긴 문제입니다.

close #55 