### PR TITLE
[#58] 탭 드래그앤드롭 버그 수정

### DIFF
--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -205,6 +205,7 @@ function Plan() {
 
   const handleDrag = ({ source, destination }: IDropEvent) => {
     if (!destination) return;
+    if (source.index === destination.index) return;
 
     if (!plan) return;
     const newTabOrder = [...plan.tabOrder];


### PR DESCRIPTION
## 📌 Description
- 탭 드래그앤드롭 버그 수정
  - source와 destination의 인덱스가 변경되었을때만 상태를 저장하도록 수정하였습니다.

## ⚠️ 주의사항
- 로직 자체는 맞았었네요 ㅎㄷㄷ
- id로만 비교해서 해결하려했는데, 상태를 저장할때 index를 찍어보니 제자리에 머물때는 index가 source와 destination이 동일하지만 이를 감지하지 못해서 생긴 버그더라구요
- 생각보다 간단하게 해결되었습니다! 역시 사람이 쉴땐 쉬어야 이런것도 잘보이는듯하네요..ㅎ

close #58