### PR TITLE
[#25, #65] 할 일 드래그앤드롭 라이브러리 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.5.1",
     "http-proxy-middleware": "^2.0.6",
     "react": "^18.2.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
     "react-router-dom": "^6.16.0",
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@craco/craco": "^7.1.0",
+    "@types/react-beautiful-dnd": "^13.1.6",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
     "eslint": "^8.50.0",

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
@@ -101,7 +101,7 @@ const DeadlineField = styled.div`
 `;
 
 interface Props {
-  addTaskHandler: (task: ITask) => void;
+  addTaskHandler: Dispatch<SetStateAction<Record<number, ITask[]>>>;
   onClose: () => void;
 }
 
@@ -152,7 +152,11 @@ export default function AddTaskModal({ addTaskHandler, onClose }: Props) {
       dateRange: checkDeadline ? [startDate, endDate] : null,
     };
     // Plan 페이지 tasks 상태에 반영
-    addTaskHandler(newTask);
+    addTaskHandler((prev) => {
+      const newTasks = { ...prev };
+      newTasks[modalInfo.tabId].push(newTask);
+      return newTasks;
+    });
     // 모달 닫기
     onClose();
   };

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { Dispatch, SetStateAction, useEffect } from 'react';
 
 import styled from 'styled-components';
 import { ITask } from 'types';
@@ -46,7 +46,7 @@ interface Props {
   description?: string;
   requestAPI: () => void;
   onClose: () => void;
-  addTaskHandler?: (task: ITask) => void;
+  addTaskHandler?: Dispatch<SetStateAction<Record<number, ITask[]>>>;
 }
 
 export default function Modal({ type, description, requestAPI, onClose, addTaskHandler }: Props) {

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -67,12 +67,13 @@ const EditableTitle = styled.input`
 const Container = styled.div`
   width: 20rem;
   height: calc(100% - 2rem);
-  padding: 1rem;
+  padding: 0.5rem;
   border-radius: 1.1rem;
   background-color: #ffffff;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 `;
 
@@ -91,6 +92,24 @@ const AddButton = styled.button`
   background-color: #fafafa;
   color: #8993a1;
   font-weight: 600;
+`;
+
+const Interactions = styled.div`
+  width: 100%;
+  /* height: rem; */
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+`;
+
+const TabDragBar = styled.button`
+  width: 95%;
+  height: 0.5rem;
+
+  background-color: lightgray;
+  border-radius: 15px;
 `;
 
 function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: ITabHeaderProps) {
@@ -143,9 +162,12 @@ export function TasksContainer({ tasks, onClickHandler }: ITaskContainerProps) {
   return (
     <Container>
       <TaskList> {tasks?.map((task) => <TaskItem key={task.id} task={task} />)}</TaskList>
-      <AddButton type="button" className="add" onClick={onClickHandler}>
-        Add Item
-      </AddButton>
+      <Interactions>
+        <AddButton type="button" className="add" onClick={onClickHandler}>
+          Add Item
+        </AddButton>
+        <TabDragBar type="button" />
+      </Interactions>
     </Container>
   );
 }

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -96,7 +96,6 @@ const AddButton = styled.button`
 
 const Interactions = styled.div`
   width: 100%;
-  /* height: rem; */
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -107,7 +106,6 @@ const Interactions = styled.div`
 const TabDragBar = styled.button`
   width: 95%;
   height: 0.5rem;
-
   background-color: lightgray;
   border-radius: 15px;
 `;
@@ -166,7 +164,7 @@ export function TasksContainer({ tasks, onClickHandler }: ITaskContainerProps) {
         <AddButton type="button" className="add" onClick={onClickHandler}>
           Add Item
         </AddButton>
-        <TabDragBar type="button" />
+        <TabDragBar type="button" draggable className="dnd-item" />
       </Interactions>
     </Container>
   );
@@ -174,7 +172,7 @@ export function TasksContainer({ tasks, onClickHandler }: ITaskContainerProps) {
 
 export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSaveTitle }: ITabProps) {
   return (
-    <Wrapper draggable data-index={index} data-id={id} className="dnd-item">
+    <Wrapper className="dnd-tab" data-index={index} data-id={id}>
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
       <TasksContainer tasks={tasks} onClickHandler={onClickHandler} />
     </Wrapper>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/require-default-props */
 /* eslint-disable react/no-unused-prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
 
 import React, { useState, useRef } from 'react';
 
+import { Droppable } from 'react-beautiful-dnd';
 import styled from 'styled-components';
 import { ITask } from 'types';
 
@@ -27,6 +29,7 @@ interface ITabHeaderProps {
 }
 
 interface ITaskContainerProps {
+  id?: number;
   tasks?: ITask[];
   onClickHandler?: () => void;
 }
@@ -80,8 +83,8 @@ const Container = styled.div`
 const TaskList = styled.ul`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  height: 570px;
+  width: 100%;
+  height: 38rem;
   overflow-y: auto;
 `;
 
@@ -156,10 +159,18 @@ function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: ITabHeaderProps) 
   );
 }
 
-export function TasksContainer({ tasks, onClickHandler }: ITaskContainerProps) {
+export function TasksContainer({ id, tasks, onClickHandler }: ITaskContainerProps) {
+  if (!id) return null;
   return (
     <Container>
-      <TaskList> {tasks?.map((task) => <TaskItem key={task.id} task={task} />)}</TaskList>
+      <Droppable droppableId={id.toString()}>
+        {(provided) => (
+          <TaskList {...provided.droppableProps} ref={provided.innerRef}>
+            {tasks?.map((task, index) => <TaskItem key={task.id} task={task} index={index} />)}
+            {provided.placeholder}
+          </TaskList>
+        )}
+      </Droppable>
       <Interactions>
         <AddButton type="button" className="add" onClick={onClickHandler}>
           Add Item
@@ -174,7 +185,7 @@ export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSa
   return (
     <Wrapper className="dnd-tab" data-index={index} data-id={id}>
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
-      <TasksContainer tasks={tasks} onClickHandler={onClickHandler} />
+      <TasksContainer id={id} tasks={tasks} onClickHandler={onClickHandler} />
     </Wrapper>
   );
 }

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,5 +1,8 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React from 'react';
 
+import { Draggable } from 'react-beautiful-dnd';
 import { IoClose, IoInfinite } from 'react-icons/io5';
 import { PiClockFill } from 'react-icons/pi';
 import { useRecoilValue } from 'recoil';
@@ -9,9 +12,10 @@ import { ITask } from 'types';
 import { filteredLabelsSelector, memberSelector } from '@recoil/selectors';
 import { hashStringToColor } from '@utils';
 
-const ItemWrapper = styled.div`
+const ItemContainer = styled.div`
   position: relative;
   padding: 1rem;
+  margin-bottom: 1rem;
   width: 18rem;
   min-height: 8rem;
   display: flex;
@@ -81,44 +85,49 @@ const DateField = styled.div`
 
 interface Props {
   task: ITask;
+  index: number;
 }
 
-export default function TaskItem({ task }: Props) {
+export default function TaskItem({ task, index }: Props) {
   const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
   const assignee = useRecoilValue(memberSelector(task.assigneeId));
 
   return (
-    <ItemWrapper>
-      <button type="button">
-        <IoClose size={20} />
-      </button>
-      <p id="task-title">{task.title}</p>
-      <LabelField>
-        {filteredLabels.map((label) => (
-          <LabelItem key={label.id} color={hashStringToColor(label.value)}>
-            {label.value}
-          </LabelItem>
-        ))}
-      </LabelField>
-      <InfoField>
-        <DateField>
-          {task.dateRange ? (
-            <>
-              <PiClockFill size={16} color="#64D4AB" />
-              <div>
-                {`${task.dateRange[0]}`}
-                <br />
-                {` ~ ${task.dateRange[1]}`}
-              </div>
-            </>
-          ) : (
-            <div className="date-infinity">
-              <IoInfinite size={24} color="#1C2A4B" />
-            </div>
-          )}
-        </DateField>
-        <div>{assignee.name}</div>
-      </InfoField>
-    </ItemWrapper>
+    <Draggable draggableId={task.id.toString()} index={index}>
+      {(provided) => (
+        <ItemContainer {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef}>
+          <button type="button">
+            <IoClose size={20} />
+          </button>
+          <p id="task-title">{task.title}</p>
+          <LabelField>
+            {filteredLabels.map((label) => (
+              <LabelItem key={label.id} color={hashStringToColor(label.value)}>
+                {label.value}
+              </LabelItem>
+            ))}
+          </LabelField>
+          <InfoField>
+            <DateField>
+              {task.dateRange ? (
+                <>
+                  <PiClockFill size={16} color="#64D4AB" />
+                  <div>
+                    {`${task.dateRange[0]}`}
+                    <br />
+                    {` ~ ${task.dateRange[1]}`}
+                  </div>
+                </>
+              ) : (
+                <div className="date-infinity">
+                  <IoInfinite size={24} color="#1C2A4B" />
+                </div>
+              )}
+            </DateField>
+            <div>{assignee.name}</div>
+          </InfoField>
+        </ItemContainer>
+      )}
+    </Draggable>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <App />,
+  // </React.StrictMode>,
 );

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -147,7 +147,7 @@ const planNameList = [
 function Plan() {
   const [originalPlan, setOriginalPlan] = useState<IPlan | null>(null);
   const [plan, setPlan] = useState<IPlan | null>(null);
-  const [tasks, setTasks] = useState<ITask[]>([]);
+  const [tasks, setTasks] = useState<Record<number, ITask[]>>({});
   const [selectedPlanName, setSelectedPlanName] = useState<string>('My Plan');
   const [newTabTitle, setNewTabTitle] = useState<string>('');
   const [isAddingTab, setIsAddingTab] = useState<boolean>(false);
@@ -175,7 +175,15 @@ function Plan() {
 
     const filteredPlan = { ...data, tasks: filteredTasks };
     setPlan(filteredPlan);
-    setTasks(filteredTasks);
+
+    const tasksByTab: Record<number, ITask[]> = {};
+    filteredTasks.forEach((task) => {
+      if (!tasksByTab[task.tabId]) {
+        tasksByTab[task.tabId] = [];
+      }
+      tasksByTab[task.tabId].push(task);
+    });
+    setTasks(tasksByTab);
   };
 
   useEffect(() => {
@@ -235,14 +243,6 @@ function Plan() {
     tabById[tab.id] = tab;
   });
   const sortedTabs = plan.tabOrder.map((tabId) => tabById[tabId]);
-
-  const tasksByTab: Record<number, ITask[]> = {};
-  tasks.forEach((task) => {
-    if (!tasksByTab[task.tabId]) {
-      tasksByTab[task.tabId] = [];
-    }
-    tasksByTab[task.tabId].push(task);
-  });
 
   const handleStartAddingTab = () => {
     setIsAddingTab(true);
@@ -356,9 +356,9 @@ function Plan() {
                 index={index}
                 title={item.title}
                 onDeleteTab={() => handleDeleteTab(item.id)}
-                tasks={tasksByTab[item.id]}
+                tasks={tasks[item.id]}
                 onClickHandler={() => {
-                  setModalInfo({ tabId: item.id, taskOrder: tasksByTab[item.id].length });
+                  setModalInfo({ tabId: item.id, taskOrder: tasks[item.id].length });
                   openModal('addTask');
                 }}
                 onSaveTitle={handleSaveTabTitle}
@@ -392,9 +392,7 @@ function Plan() {
         <Modal
           type={showModal}
           onClose={closeModal}
-          addTaskHandler={(task: ITask): void => {
-            setTasks([...tasks, task]);
-          }}
+          addTaskHandler={setTasks}
           requestAPI={() => {
             // TODO: 할 일 추가 API 입력
           }}

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 
+import { DragDropContext, OnDragEndResponder } from 'react-beautiful-dnd';
 import { CiSettings } from 'react-icons/ci';
 import { IoIosStarOutline } from 'react-icons/io';
 import { SlPlus } from 'react-icons/sl';
@@ -103,6 +104,10 @@ const UtilContainer = styled.div`
 const TabGroup = styled.ul`
   width: calc(100vw - 22rem);
   height: calc(100% - 4rem);
+  display: flex;
+`;
+
+const TabContainer = styled.div`
   display: flex;
   gap: 1.5rem;
   overflow-x: auto;
@@ -314,6 +319,66 @@ function Plan() {
     return title;
   };
 
+  interface IDragDropResult {
+    source: {
+      droppableId: string;
+      index: number;
+    };
+    destination: {
+      droppableId: string;
+      index: number;
+    };
+    draggableId: string;
+  }
+
+  const onDragEnd = (result: IDragDropResult) => {
+    const { destination, source } = result;
+
+    if (!destination) return;
+
+    if (destination.droppableId === source.droppableId && destination.index === source.index) return;
+
+    const start = tasks[+source.droppableId];
+    const finish = tasks[+destination.droppableId];
+
+    const updatedTask = start[source.index];
+    start.splice(source.index, 1);
+
+    if (start === finish) {
+      start.splice(destination.index, 0, updatedTask);
+
+      setTasks((prev) => {
+        const newTasks = { ...prev };
+        newTasks[+source.droppableId] = [...start];
+        return newTasks;
+      });
+      return;
+    }
+
+    updatedTask.tabId = +destination.droppableId;
+    finish.splice(destination.index, 0, updatedTask);
+
+    const newStart = [...start].map((item, index) => {
+      const newItem = { ...item };
+      newItem.order = index;
+      return item;
+    });
+    const newFinish = [...finish].map((item, index) => {
+      const newItem = { ...item };
+      newItem.order = index;
+      return item;
+    });
+
+    setTasks((prev) => {
+      const newTasks = {
+        ...prev,
+        [source.droppableId]: newStart,
+        [destination.droppableId]: newFinish,
+      };
+      return newTasks;
+    });
+  };
+
   return (
     <Wrapper>
       <SideContainer>
@@ -348,41 +413,45 @@ function Plan() {
           </UtilContainer>
         </TopContainer>
         <TabGroup data-droppable-id={1} className="droppable">
-          {sortedTabs.map((item, index) => {
-            return (
-              <Tab
-                id={item.id}
-                key={item.id}
-                index={index}
-                title={item.title}
-                onDeleteTab={() => handleDeleteTab(item.id)}
-                tasks={tasks[item.id]}
-                onClickHandler={() => {
-                  setModalInfo({ tabId: item.id, taskOrder: tasks[item.id].length });
-                  openModal('addTask');
-                }}
-                onSaveTitle={handleSaveTabTitle}
-              />
-            );
-          })}
-          {isAddingTab && (
-            <TabWrapper>
-              <input
-                type="text"
-                ref={inputRef}
-                value={newTabTitle}
-                onChange={(e) => setNewTabTitle(e.target.value)}
-                onBlur={handleAddTab}
-                onKeyDown={handleInputKeyDown}
-              />
-              {/* TODO 탭 추가하다 취소하는 버튼 추가 */}
-              <TasksContainer
-                onClickHandler={() => {
-                  openModal('addTask');
-                }}
-              />
-            </TabWrapper>
-          )}
+          <DragDropContext onDragEnd={onDragEnd as OnDragEndResponder}>
+            <TabContainer>
+              {sortedTabs.map((item, index) => {
+                return (
+                  <Tab
+                    id={item.id}
+                    key={item.id}
+                    index={index}
+                    title={item.title}
+                    onDeleteTab={() => handleDeleteTab(item.id)}
+                    tasks={tasks[item.id]}
+                    onClickHandler={() => {
+                      setModalInfo({ tabId: item.id, taskOrder: tasks[item.id].length });
+                      openModal('addTask');
+                    }}
+                    onSaveTitle={handleSaveTabTitle}
+                  />
+                );
+              })}
+              {isAddingTab && (
+                <TabWrapper>
+                  <input
+                    type="text"
+                    ref={inputRef}
+                    value={newTabTitle}
+                    onChange={(e) => setNewTabTitle(e.target.value)}
+                    onBlur={handleAddTab}
+                    onKeyDown={handleInputKeyDown}
+                  />
+                  {/* TODO 탭 추가하다 취소하는 버튼 추가 */}
+                  <TasksContainer
+                    onClickHandler={() => {
+                      openModal('addTask');
+                    }}
+                  />
+                </TabWrapper>
+              )}
+            </TabContainer>
+          </DragDropContext>
           <AddTapButton>
             <SlPlus size={35} color="#8993A1" onClick={handleStartAddingTab} />
           </AddTapButton>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,6 +1241,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.15.4":
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
+  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.22.5", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -2267,6 +2274,14 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz#cc477ce0283bb9d19ea0cbfa2941fe2c8493a1be"
+  integrity sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
@@ -2379,12 +2394,29 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/react-beautiful-dnd@^13.1.6":
+  version "13.1.6"
+  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.6.tgz#a616443903bfc370fee298b0144dbce7234d5561"
+  integrity sha512-FXAuaa52ux7HWQDumi3MFSAAsW8OKfDImy1pSZPKe85nV9mZ1f4spVzW0a2boYvkIhphjbWUi5EwUiRG8Rq/Qg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^18.0.0":
   version "18.2.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
   integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.28"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.28.tgz#30a44303c7daceb6ede9cfb4aaf72e64f1dde4de"
+  integrity sha512-EQr7cChVzVUuqbA+J8ArWK1H0hLAHKOs21SIMrskKZ3nHNeE+LFYA+IsoZGhVOT8Ktjn3M20v4rnZKN3fLbypw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-router-dom@^5.3.3":
   version "5.3.3"
@@ -3887,6 +3919,13 @@ css-blank-pseudo@^3.0.3:
   integrity sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==
   dependencies:
     postcss-selector-parser "^6.0.9"
+
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -5554,7 +5593,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7084,6 +7123,11 @@ memfs@^3.1.2, memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.4"
 
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -8300,7 +8344,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8354,6 +8398,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -8394,6 +8443,19 @@ react-app-polyfill@^3.0.0:
     raf "^3.4.1"
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
+
+react-beautiful-dnd@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
+  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-dev-utils@^12.0.1:
   version "12.0.1"
@@ -8448,7 +8510,7 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -8457,6 +8519,18 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-redux@^7.2.0:
+  version "7.2.9"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
+  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -8597,6 +8671,13 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.0.0, redux@^4.0.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"
@@ -9610,6 +9691,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tiny-invariant@^1.0.6:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
+  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
+
 titleize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
@@ -9912,6 +9998,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## 📌 Description
- `react-beautiful-dnd`를 이용하여 할 일 드래그앤드롭을 구현했습니다.
- 탭 드래그앤드롭은 탭 하단의 드래그바를 이용하여 드래그할 수 있도록 수정하였습니다.
- 플랜 페이지에서 태스크를 저장할때 탭별로 태스크가 나누어진 객체를 저장하도록 수정하였습니다.

## ⚠️ 주의사항
- 탭 또한 라이브러리를 이용하여 구현하려 했지만, 마찬가지로 충돌이 일어나서 기존에 현님이 구현한 드래그앤드롭을 유지해두었습니다.
  - 여러 방법으로 시도해보았지만 안되네요..... 추후 다시 해보겠습니다 ㅠ
- 탭 생성 후 해당 탭으로 드래그하거나 할 일 추가시 에러가 나는 버그가 아직 존재합니다 ㅠ
- 아참 위의 라이브러리가 React.strictMode에선 동작하지 않아서 빼는 것도 좋을 것 같습니다!

close #25, #65 