### PR TITLE
[#30] 플랜 설정 페이지 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import CreatePlan from '@pages/CreatePlan';
 import GoogleOauthCallback from '@pages/GoogleOauthCallback';
 import Main from '@pages/Main';
 import Plan from '@pages/Plan';
+import Setting from '@pages/Setting';
 import SignIn from '@pages/SignIn';
 import SignUp from '@pages/SignUp';
 import GlobalFonts from '@styles/GlobalFont';
@@ -39,6 +40,10 @@ const router = createBrowserRouter([
       {
         path: '/plan',
         element: <Plan />,
+      },
+      {
+        path: '/setting',
+        element: <Setting />,
       },
     ],
   },

--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
@@ -60,15 +61,16 @@ const SelectBoxArrow = styled.svg<{ $showOptions: boolean }>`
 `;
 interface Props {
   options: ISelectOption[];
+  value?: ISelectOption;
   setValue: Dispatch<SetStateAction<ISelectOption>>;
 }
 
-export default function SelectBox({ options, setValue }: Props) {
+export default function SelectBox({ options, value, setValue }: Props) {
   const [selectedValue, setSelectedValue] = useState<ISelectOption>(options[0]);
   const [showOptions, setShowOptions] = useState<boolean>(false);
 
   useEffect(() => {
-    setValue(options[0]);
+    setValue(value || options[0]);
   }, [setValue]);
 
   return (

--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -66,7 +66,7 @@ interface Props {
 }
 
 export default function SelectBox({ options, value, setValue }: Props) {
-  const [selectedValue, setSelectedValue] = useState<ISelectOption>(options[0]);
+  const [selectedValue, setSelectedValue] = useState<ISelectOption>(value || options[0]);
   const [showOptions, setShowOptions] = useState<boolean>(false);
 
   useEffect(() => {

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -90,7 +90,7 @@ interface Props {
 
 export default function TaskItem({ task, index }: Props) {
   const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
-  const assignee = useRecoilValue(memberSelector(task.assigneeId));
+  const assignee = useRecoilValue(memberSelector(task.assigneeId!));
 
   return (
     <Draggable draggableId={task.id.toString()} index={index}>

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -173,7 +173,7 @@ function Plan() {
       // 라벨 배열의 길이가 0보다 클때만 라벨 필터링
       const labelFilter = labels.length === 0 || task.labels.some((label) => labels.includes(label));
       // 멤버 필터링
-      const memberFilter = members.length === 0 || members.includes(task.assigneeId);
+      const memberFilter = members.length === 0 || members.includes(task.assigneeId!);
 
       return labelFilter && memberFilter;
     });

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,9 +1,12 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, { useEffect, useState, useRef } from 'react';
 
 import { DragDropContext, OnDragEndResponder } from 'react-beautiful-dnd';
 import { CiSettings } from 'react-icons/ci';
 import { IoIosStarOutline } from 'react-icons/io';
 import { SlPlus } from 'react-icons/sl';
+import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { ITask, ITab, IMember, ILabel } from 'types';
@@ -163,6 +166,8 @@ function Plan() {
   const setMembers = useSetRecoilState(membersState);
   const setLabels = useSetRecoilState(labelsState);
   const setModalInfo = useSetRecoilState(modalState);
+
+  const navigate = useNavigate();
 
   const filterAndSetPlan = (data: IPlan, labels: number[], members: number[]) => {
     if (!data) {
@@ -407,7 +412,7 @@ function Plan() {
             <div className="icon">
               <IoIosStarOutline size={25} />
             </div>
-            <div className="icon">
+            <div className="icon" onClick={() => navigate('/setting')}>
               <CiSettings size={28} />
             </div>
           </UtilContainer>

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,0 +1,467 @@
+import React, { useState } from 'react';
+
+import { MdOutlineClose } from 'react-icons/md';
+import styled from 'styled-components';
+
+// import SelectBox from '@components/SelectBox';
+import ToggleSwitch from '@components/ToggleSwitch';
+
+interface IPlanInfo {
+  title: string;
+  description: string;
+}
+
+const Wrapper = styled.div`
+  width: 100vw;
+  min-height: 100vh;
+  padding: 110px 70px 40px;
+`;
+
+const InputField = styled.div`
+  label {
+    font-weight: 600;
+  }
+
+  input {
+    display: block;
+    width: 100%;
+    padding: 1rem;
+    margin-top: 8px;
+    border-radius: 8px;
+    background-color: #fafafa;
+
+    &:focus {
+      outline: 1px solid #b8b8b84f;
+    }
+  }
+`;
+
+const MemberItem = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #000;
+
+  button {
+    background-color: inherit;
+  }
+`;
+
+const ManageTeam = styled.div`
+  width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  h3 {
+    font-weight: 600;
+  }
+
+  input {
+    width: 100%;
+    height: 2.7rem;
+    border-radius: 0.5rem;
+    border: 1px solid #d1d1d1;
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    &::placeholder {
+      color: #939393;
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+`;
+
+const ManageTeamContainer = styled.div`
+  background-color: #fafafa;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
+  color: #939393;
+  font-size: 14px;
+`;
+
+const MemberList = styled.div`
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.7rem;
+
+    .subTitle {
+      font-size: 1rem;
+    }
+  }
+`;
+
+const ExistItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+
+  .memberInfo {
+    display: flex;
+    flex-direction: column;
+
+    .name {
+      font-weight: 600;
+      color: #000;
+    }
+  }
+
+  button {
+    border-radius: 0.5rem;
+    border: 1px solid #d1d1d1;
+    color: #939393;
+    padding-inline: 0.9rem;
+    height: 2.2rem;
+  }
+`;
+
+const DangerZone = styled.div`
+  .set {
+    display: flex;
+    align-items: center;
+    gap: 3.8rem;
+  }
+`;
+
+const DeleteButton = styled.button`
+  font-size: 14px;
+  height: 2.4rem;
+  padding-inline: 1.5rem;
+  background-color: #ff5353;
+  border-radius: 0.5rem;
+  color: #fff;
+`;
+
+const SelectBoxContainer = styled.div`
+  position: relative;
+  width: 6rem;
+  height: 2rem;
+  display: flex;
+  border-radius: 8px;
+  background-color: #fafafa;
+  align-items: center;
+  justify-content: space-between;
+
+  cursor: pointer;
+`;
+
+const Selected = styled.label`
+  font-size: 14px;
+  margin-left: 4px;
+  width: 4rem;
+  text-align: center;
+`;
+
+const SelectOptions = styled.ul`
+  position: absolute;
+  list-style: none;
+  top: 2rem;
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  padding: 0;
+  border-radius: 8px;
+  background-color: #fafafa;
+  z-index: 100;
+`;
+
+const Option = styled.li`
+  font-size: 14px;
+  padding: 6px 8px;
+  text-align: center;
+  transition: background-color 0.2s ease-in;
+  &:hover {
+    background-color: #64d4ab;
+  }
+`;
+
+const SelectBoxArrowContainer = styled.div`
+  width: 25px;
+  height: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const SelectBoxArrow = styled.svg<{ $showOptions: boolean }>`
+  transition-duration: 0.3s;
+  transform: rotate(${(props) => (props.$showOptions ? '180deg' : 0)});
+`;
+
+const ManageAdmin = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const Button = styled.button`
+  font-size: 14px;
+  height: 2.4rem;
+  padding-inline: 1.5rem;
+  background-color: #64d4ab;
+  border-radius: 0.5rem;
+  color: #fff;
+`;
+
+const planData = {
+  title: 'planting',
+  description: '안녕하세요 저희는 일정 공유 관리 서비스를 개발하고 있는 플랜팅입니다.',
+  isPublic: true,
+  members: [
+    {
+      id: 1,
+      name: '신우성',
+      imgUrl:
+        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+      isAdmin: true,
+      email: 'cys@gmail.com',
+    },
+    {
+      id: 2,
+      name: '김태훈',
+      imgUrl:
+        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+      isAdmin: false,
+      email: 'kth@gmail.com',
+    },
+    {
+      id: 3,
+      name: '허준영',
+      imgUrl:
+        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+      isAdmin: false,
+      email: 'hjy@gmail.com',
+    },
+    {
+      id: 4,
+      name: '한현',
+      imgUrl:
+        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+      isAdmin: false,
+      email: 'hh@gmail.com',
+    },
+  ],
+  tabOrder: [2, 1, 3],
+  tabs: [
+    {
+      id: 3,
+      title: 'Done',
+    },
+    {
+      id: 1,
+      title: 'To do',
+    },
+    {
+      id: 2,
+      title: 'In Progress',
+    },
+  ],
+  labels: [
+    { id: 1, value: '개발도서' },
+    { id: 2, value: '코테' },
+    { id: 3, value: '이력서' },
+  ],
+  tasks: [
+    {
+      id: 1,
+      title: 'NC SOFT 서류 제출',
+      tabId: 3,
+      labels: [3],
+      assigneeId: 3,
+      order: 0,
+    },
+    {
+      id: 2,
+      title: '이펙티브 완독',
+      tabId: 1,
+      labels: [1],
+      assigneeId: 3,
+      order: 0,
+    },
+    {
+      id: 3,
+      title: '타입스크립트 Chap1',
+      tabId: 2,
+      labels: [1],
+      assigneeId: 4,
+      order: 0,
+    },
+    {
+      id: 4,
+      title: '백준 삼성 기출',
+      tabId: 2,
+      labels: [2],
+      assigneeId: 1,
+      order: 1,
+    },
+  ],
+};
+
+function Setting() {
+  const [planInfo, setPlanInfo] = useState<IPlanInfo>({
+    title: planData.title,
+    description: planData.description,
+  });
+  const [memberEmailList, setMemberEmailList] = useState<string[]>([]);
+  const [isPublic, setIsPublic] = useState<boolean>(planData.isPublic);
+  const admin = planData.members.find((item) => item.isAdmin === true)?.name;
+  const [adminName, setAdminName] = useState<string | null>(admin || null);
+  const [showOptions, setShowOptions] = useState<boolean>(false);
+  const [deletedList, setDeletedList] = useState<number[]>([]);
+
+  const changePlanInfo = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setPlanInfo((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const addMember = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value.trim();
+    if (e.key !== 'Enter' || !value) return;
+    setMemberEmailList((prev) => [...prev, value]);
+    e.currentTarget.value = '';
+  };
+
+  const deleteMember = (deletedEmail: string) => {
+    const updatedMembers = memberEmailList.filter((email) => email !== deletedEmail);
+    setMemberEmailList(updatedMembers);
+  };
+
+  const togglePublic = () => {
+    setIsPublic((prev) => !prev);
+  };
+
+  const handleDelete = (deletedId: number) => {
+    setDeletedList((prev) => {
+      if (prev.includes(deletedId)) {
+        return prev.filter((id) => id !== deletedId);
+      }
+      return [...prev, deletedId];
+    });
+  };
+
+  return (
+    <Wrapper>
+      <InputField>
+        <label htmlFor="title">
+          플랜 제목
+          <input
+            type="text"
+            id="title"
+            name="title"
+            value={planInfo.title}
+            onChange={changePlanInfo}
+            placeholder="플랜 이름을 알려주세요"
+          />
+        </label>
+      </InputField>
+      <InputField>
+        <label htmlFor="description">
+          플랜 설명
+          <input
+            type="text"
+            id="description"
+            name="description"
+            value={planInfo.description}
+            onChange={changePlanInfo}
+            placeholder="플랜을 설명해주세요"
+          />
+        </label>
+      </InputField>
+      <ManageTeam>
+        <h3>팀원 관리</h3>
+        <input
+          type="email"
+          id="members"
+          name="members"
+          onKeyUp={addMember}
+          placeholder="초대할 팀원의 이메일을 알려주세요"
+        />
+        <ManageTeamContainer>
+          <MemberList>
+            <span className="subTitle">새로 초대할 팀원</span>
+            <ul>
+              {memberEmailList.map((item) => (
+                <MemberItem key={item}>
+                  {item}
+                  <button type="button" onClick={() => deleteMember(item)}>
+                    <MdOutlineClose size="16" color="#939393" />
+                  </button>
+                </MemberItem>
+              ))}
+            </ul>
+          </MemberList>
+          <MemberList>
+            <span className="subTitle">팀원 현황</span>
+            <ul>
+              {planData.members.map((item) => (
+                <ExistItem key={item.id}>
+                  <div className="memberInfo">
+                    <span className="name">{item.name}</span>
+                    <span>{item.email}</span>
+                  </div>
+                  {deletedList.includes(item.id) && <p>삭제 예정</p>}
+                  <button type="button" onClick={() => handleDelete(item.id)}>
+                    {deletedList.includes(item.id) ? '되돌리기' : '삭제'}
+                  </button>
+                </ExistItem>
+              ))}
+            </ul>
+          </MemberList>
+        </ManageTeamContainer>
+      </ManageTeam>
+      <DangerZone>
+        <span className="subTitle">중요 설정 변경</span>
+        <div className="set">
+          <ManageAdmin>
+            <span>관리자</span>
+            <SelectBoxContainer onClick={() => setShowOptions((prev) => !prev)}>
+              <Selected>{adminName}</Selected>
+              {showOptions && (
+                <SelectOptions>
+                  {planData.members.map((option) => (
+                    <Option
+                      key={option.id}
+                      value={option.name}
+                      onClick={() => {
+                        setAdminName(option.name);
+                      }}
+                    >
+                      {option.name}
+                    </Option>
+                  ))}
+                </SelectOptions>
+              )}
+              <SelectBoxArrowContainer>
+                <SelectBoxArrow
+                  $showOptions={showOptions}
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="11"
+                  height="6"
+                  viewBox="0 0 11 6"
+                  fill="none"
+                >
+                  <path d="M0.291664 0.416748L5.5 5.62508L10.7083 0.416748H0.291664Z" fill="#8993A1" />
+                </SelectBoxArrow>
+              </SelectBoxArrowContainer>
+            </SelectBoxContainer>
+          </ManageAdmin>
+          <ManageAdmin>
+            <span>{isPublic ? '플랜을 공개할게요' : '플랜을 공개하지 않아요'}</span>
+            <ToggleSwitch isPublic={isPublic} onChange={togglePublic} />
+          </ManageAdmin>
+          <DeleteButton type="button">플랜 삭제</DeleteButton>
+        </div>
+      </DangerZone>
+      <Button type="submit">변경사항 저장</Button>
+    </Wrapper>
+  );
+}
+
+export default Setting;

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -15,6 +15,15 @@ const Wrapper = styled.div`
   width: 100vw;
   min-height: 100vh;
   padding: 110px 70px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const Title = styled.h2`
+  font-size: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgb(216, 222, 228);
 `;
 
 const InputField = styled.div`
@@ -24,26 +33,28 @@ const InputField = styled.div`
 
   input {
     display: block;
-    width: 100%;
-    padding: 1rem;
-    margin-top: 8px;
-    border-radius: 8px;
+    width: 75rem;
+    height: 2.2rem;
+    padding: 0.5rem 0.7rem;
+    margin-top: 0.4rem;
+    border: 1px solid rgb(208, 215, 222);
+    border-radius: 6px;
+    outline: none;
     background-color: #fafafa;
+    font-size: 14px;
+
+    &.email {
+      width: 600px;
+      margin-top: 0;
+    }
+
+    &::placeholder {
+      font-size: inherit;
+    }
 
     &:focus {
-      outline: 1px solid #b8b8b84f;
+      border: 2px solid #64d4ab;
     }
-  }
-`;
-
-const MemberItem = styled.li`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: #000;
-
-  button {
-    background-color: inherit;
   }
 `;
 
@@ -51,57 +62,47 @@ const ManageTeam = styled.div`
   width: 600px;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
 
   h3 {
     font-weight: 600;
-  }
-
-  input {
-    width: 100%;
-    height: 2.7rem;
-    border-radius: 0.5rem;
-    border: 1px solid #d1d1d1;
-    padding: 0.5rem 1rem;
-    font-size: 1rem;
-    &::placeholder {
-      color: #939393;
-    }
-
-    &:focus {
-      outline: none;
-    }
   }
 `;
 
 const ManageTeamContainer = styled.div`
   background-color: #fafafa;
-  padding: 2rem;
+  padding: 1rem;
+  border: 1px solid rgb(208, 215, 222);
   border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
-  gap: 3rem;
+  gap: 2rem;
 
   color: #939393;
   font-size: 14px;
 `;
 
 const MemberList = styled.div`
+  .subTitle {
+    font-weight: 600;
+  }
+
   ul {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    margin-top: 0.7rem;
-
-    .subTitle {
-      font-size: 1rem;
-    }
+    margin-top: 0.5rem;
   }
 `;
 
-const ExistItem = styled.li`
+const MemberItem = styled.li`
   display: flex;
   justify-content: space-between;
+  align-items: center;
+
+  .invite {
+    color: #000;
+  }
 
   .memberInfo {
     display: flex;
@@ -113,12 +114,42 @@ const ExistItem = styled.li`
     }
   }
 
+  .delete {
+    display: flex;
+    align-items: center;
+
+    .pending {
+      margin-right: 1rem;
+      color: #cf2d7b;
+      font-weight: 600;
+    }
+  }
+
   button {
-    border-radius: 0.5rem;
-    border: 1px solid #d1d1d1;
+    font-weight: 600;
     color: #939393;
-    padding-inline: 0.9rem;
-    height: 2.2rem;
+
+    &.invite {
+      height: fit-content;
+      border: none;
+    }
+
+    &.exist {
+      border-radius: 0.5rem;
+      border: 1px solid #d1d1d1;
+      padding-inline: 0.9rem;
+      height: 2.2rem;
+      transition:
+        color,
+        background-color,
+        border 0.3s cubic-bezier(0.33, 1, 0.68, 1);
+
+      &:hover {
+        background-color: #ff5353;
+        color: #fff;
+        border: none;
+      }
+    }
   }
 `;
 
@@ -202,6 +233,8 @@ const ManageAdmin = styled.div`
 `;
 
 const Button = styled.button`
+  align-self: center;
+  width: fit-content;
   font-size: 14px;
   height: 2.4rem;
   padding-inline: 1.5rem;
@@ -348,6 +381,7 @@ function Setting() {
 
   return (
     <Wrapper>
+      <Title>플랜 설정</Title>
       <InputField>
         <label htmlFor="title">
           플랜 제목
@@ -376,21 +410,24 @@ function Setting() {
       </InputField>
       <ManageTeam>
         <h3>팀원 관리</h3>
-        <input
-          type="email"
-          id="members"
-          name="members"
-          onKeyUp={addMember}
-          placeholder="초대할 팀원의 이메일을 알려주세요"
-        />
+        <InputField>
+          <input
+            type="email"
+            id="members"
+            name="members"
+            className="email"
+            onKeyUp={addMember}
+            placeholder="초대할 팀원의 이메일을 알려주세요"
+          />
+        </InputField>
         <ManageTeamContainer>
           <MemberList>
-            <span className="subTitle">새로 초대할 팀원</span>
+            <span className="subTitle">새로운 팀원</span>
             <ul>
               {memberEmailList.map((item) => (
                 <MemberItem key={item}>
-                  {item}
-                  <button type="button" onClick={() => deleteMember(item)}>
+                  <span className="invite">{item}</span>
+                  <button type="button" onClick={() => deleteMember(item)} className="invite">
                     <MdOutlineClose size="16" color="#939393" />
                   </button>
                 </MemberItem>
@@ -401,16 +438,18 @@ function Setting() {
             <span className="subTitle">팀원 현황</span>
             <ul>
               {planData.members.map((item) => (
-                <ExistItem key={item.id}>
+                <MemberItem key={item.id}>
                   <div className="memberInfo">
                     <span className="name">{item.name}</span>
                     <span>{item.email}</span>
                   </div>
-                  {deletedList.includes(item.id) && <p>삭제 예정</p>}
-                  <button type="button" onClick={() => handleDelete(item.id)}>
-                    {deletedList.includes(item.id) ? '되돌리기' : '삭제'}
-                  </button>
-                </ExistItem>
+                  <div className="delete">
+                    {deletedList.includes(item.id) && <span className="pending">삭제 예정</span>}
+                    <button type="button" onClick={() => handleDelete(item.id)} className="exist">
+                      {deletedList.includes(item.id) ? '되돌리기' : '삭제'}
+                    </button>
+                  </div>
+                </MemberItem>
               ))}
             </ul>
           </MemberList>

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -295,42 +295,52 @@ function Setting() {
     title: planData.title,
     description: planData.description,
   });
-  const [memberEmailList, setMemberEmailList] = useState<string[]>([]);
-  const [isPublic, setIsPublic] = useState<boolean>(planData.isPublic);
+  const [newMemberEmailList, setNewMemberEmailList] = useState<string[]>([]);
   const initialAdmin = planData.members.find((item) => item.isAdmin === true);
+  const [deletedExistMemberIdList, setDeletedExistMemberIdList] = useState<number[]>([]);
   const [admin, setAdmin] = useState<ISelectOption>({ id: initialAdmin?.id, name: initialAdmin?.name });
-  const [deletedList, setDeletedList] = useState<number[]>([]);
+  const [isPublic, setIsPublic] = useState<boolean>(planData.isPublic);
+
   const options = planData.members.map((member) => {
     return { id: member.id, name: member.name };
   });
+
   const changePlanInfo = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setPlanInfo((prev) => ({ ...prev, [name]: value }));
   };
 
-  const addMember = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleAddMember = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const value = e.currentTarget.value.trim();
     if (e.key !== 'Enter' || !value) return;
-    setMemberEmailList((prev) => [...prev, value]);
+    setNewMemberEmailList((prev) => [...prev, value]);
     e.currentTarget.value = '';
   };
 
-  const deleteMember = (deletedEmail: string) => {
-    const updatedMembers = memberEmailList.filter((email) => email !== deletedEmail);
-    setMemberEmailList(updatedMembers);
+  const handleDeleteNewMember = (deletedEmail: string) => {
+    const updatedMembers = newMemberEmailList.filter((email) => email !== deletedEmail);
+    setNewMemberEmailList(updatedMembers);
   };
 
   const togglePublic = () => {
     setIsPublic((prev) => !prev);
   };
 
-  const handleDelete = (deletedId: number) => {
-    setDeletedList((prev) => {
+  const handleDeleteExistMember = (deletedId: number) => {
+    setDeletedExistMemberIdList((prev) => {
       if (prev.includes(deletedId)) {
         return prev.filter((id) => id !== deletedId);
       }
       return [...prev, deletedId];
     });
+  };
+
+  const handleDeletePlan = () => {
+    // TODO: 서버에 플랜 삭제 요청
+  };
+
+  const handleSavePlan = () => {
+    // TODO: 서버에 플랜 수정 요청
   };
 
   return (
@@ -370,7 +380,7 @@ function Setting() {
             id="members"
             name="members"
             className="email"
-            onKeyUp={addMember}
+            onKeyUp={handleAddMember}
             placeholder="초대할 팀원의 이메일을 알려주세요"
           />
         </InputField>
@@ -378,10 +388,10 @@ function Setting() {
           <MemberList>
             <span className="subTitle">새로운 팀원</span>
             <ul>
-              {memberEmailList.map((item) => (
+              {newMemberEmailList.map((item) => (
                 <MemberItem key={item}>
                   <span className="invite">{item}</span>
-                  <button type="button" onClick={() => deleteMember(item)} className="invite">
+                  <button type="button" onClick={() => handleDeleteNewMember(item)} className="invite">
                     <MdOutlineClose size="16" color="#939393" />
                   </button>
                 </MemberItem>
@@ -398,9 +408,9 @@ function Setting() {
                     <span>{item.email}</span>
                   </div>
                   <div className="delete">
-                    {deletedList.includes(item.id) && <span className="pending">삭제 예정</span>}
-                    <button type="button" onClick={() => handleDelete(item.id)} className="exist">
-                      {deletedList.includes(item.id) ? '되돌리기' : '삭제'}
+                    {deletedExistMemberIdList.includes(item.id) && <span className="pending">삭제 예정</span>}
+                    <button type="button" onClick={() => handleDeleteExistMember(item.id)} className="exist">
+                      {deletedExistMemberIdList.includes(item.id) ? '되돌리기' : '삭제'}
                     </button>
                   </div>
                 </MemberItem>
@@ -421,10 +431,10 @@ function Setting() {
         </SettingItem>
       </ImportantSetting>
       <ButtonContainer>
-        <Button type="button" className="delete">
+        <Button type="button" className="delete" onClick={handleDeletePlan}>
           플랜 삭제
         </Button>
-        <Button type="submit" className="save">
+        <Button type="submit" className="save" onClick={handleSavePlan}>
           변경사항 저장
         </Button>
       </ButtonContainer>

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -161,15 +161,6 @@ const DangerZone = styled.div`
   }
 `;
 
-const DeleteButton = styled.button`
-  font-size: 14px;
-  height: 2.4rem;
-  padding-inline: 1.5rem;
-  background-color: #ff5353;
-  border-radius: 0.5rem;
-  color: #fff;
-`;
-
 const SelectBoxContainer = styled.div`
   position: relative;
   width: 6rem;
@@ -232,15 +223,28 @@ const ManageAdmin = styled.div`
   gap: 1rem;
 `;
 
-const Button = styled.button`
+const ButtonContainer = styled.div`
   align-self: center;
-  width: fit-content;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const Button = styled.button`
   font-size: 14px;
   height: 2.4rem;
   padding-inline: 1.5rem;
-  background-color: #64d4ab;
+  border: none;
   border-radius: 0.5rem;
   color: #fff;
+
+  &.save {
+    background-color: #64d4ab;
+  }
+
+  &.delete {
+    background-color: #ff5353;
+  }
 `;
 
 const planData = {
@@ -456,7 +460,7 @@ function Setting() {
         </ManageTeamContainer>
       </ManageTeam>
       <DangerZone>
-        <span className="subTitle">중요 설정 변경</span>
+        <h3>중요 설정 변경</h3>
         <div className="set">
           <ManageAdmin>
             <span>관리자</span>
@@ -495,10 +499,16 @@ function Setting() {
             <span>{isPublic ? '플랜을 공개할게요' : '플랜을 공개하지 않아요'}</span>
             <ToggleSwitch isPublic={isPublic} onChange={togglePublic} />
           </ManageAdmin>
-          <DeleteButton type="button">플랜 삭제</DeleteButton>
         </div>
       </DangerZone>
-      <Button type="submit">변경사항 저장</Button>
+      <ButtonContainer>
+        <Button type="button" className="delete">
+          플랜 삭제
+        </Button>
+        <Button type="submit" className="save">
+          변경사항 저장
+        </Button>
+      </ButtonContainer>
     </Wrapper>
   );
 }

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -154,20 +154,6 @@ const MemberItem = styled.li`
   }
 `;
 
-const DangerZone = styled.div`
-  .set {
-    display: flex;
-    align-items: center;
-    gap: 3.8rem;
-  }
-`;
-
-const ManageAdmin = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-`;
-
 const ButtonContainer = styled.div`
   align-self: center;
   display: flex;
@@ -190,6 +176,24 @@ const Button = styled.button`
   &.delete {
     background-color: #ff5353;
   }
+`;
+
+const ImportantSetting = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 14px;
+
+  h3 {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+`;
+
+const SettingItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 `;
 
 const planData = {
@@ -405,19 +409,17 @@ function Setting() {
           </MemberList>
         </ManageTeamContainer>
       </ManageTeam>
-      <DangerZone>
+      <ImportantSetting>
         <h3>중요 설정 변경</h3>
-        <div className="set">
-          <ManageAdmin>
-            <span>관리자</span>
-            <SelectBox options={options} value={admin} setValue={setAdmin} />
-          </ManageAdmin>
-          <ManageAdmin>
-            <span>{isPublic ? '플랜을 공개할게요' : '플랜을 공개하지 않아요'}</span>
-            <ToggleSwitch isPublic={isPublic} onChange={togglePublic} />
-          </ManageAdmin>
-        </div>
-      </DangerZone>
+        <SettingItem>
+          <span>관리자</span>
+          <SelectBox options={options} value={admin} setValue={setAdmin} />
+        </SettingItem>
+        <SettingItem>
+          <span>공개 여부</span>
+          <ToggleSwitch isPublic={isPublic} onChange={togglePublic} />
+        </SettingItem>
+      </ImportantSetting>
       <ButtonContainer>
         <Button type="button" className="delete">
           플랜 삭제

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 
 import { MdOutlineClose } from 'react-icons/md';
 import styled from 'styled-components';
+import { ISelectOption } from 'types';
 
-// import SelectBox from '@components/SelectBox';
+import SelectBox from '@components/SelectBox';
 import ToggleSwitch from '@components/ToggleSwitch';
 
 interface IPlanInfo {
@@ -161,62 +162,6 @@ const DangerZone = styled.div`
   }
 `;
 
-const SelectBoxContainer = styled.div`
-  position: relative;
-  width: 6rem;
-  height: 2rem;
-  display: flex;
-  border-radius: 8px;
-  background-color: #fafafa;
-  align-items: center;
-  justify-content: space-between;
-
-  cursor: pointer;
-`;
-
-const Selected = styled.label`
-  font-size: 14px;
-  margin-left: 4px;
-  width: 4rem;
-  text-align: center;
-`;
-
-const SelectOptions = styled.ul`
-  position: absolute;
-  list-style: none;
-  top: 2rem;
-  left: 0;
-  width: 100%;
-  overflow: hidden;
-  padding: 0;
-  border-radius: 8px;
-  background-color: #fafafa;
-  z-index: 100;
-`;
-
-const Option = styled.li`
-  font-size: 14px;
-  padding: 6px 8px;
-  text-align: center;
-  transition: background-color 0.2s ease-in;
-  &:hover {
-    background-color: #64d4ab;
-  }
-`;
-
-const SelectBoxArrowContainer = styled.div`
-  width: 25px;
-  height: 25px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const SelectBoxArrow = styled.svg<{ $showOptions: boolean }>`
-  transition-duration: 0.3s;
-  transform: rotate(${(props) => (props.$showOptions ? '180deg' : 0)});
-`;
-
 const ManageAdmin = styled.div`
   display: flex;
   align-items: center;
@@ -348,11 +293,12 @@ function Setting() {
   });
   const [memberEmailList, setMemberEmailList] = useState<string[]>([]);
   const [isPublic, setIsPublic] = useState<boolean>(planData.isPublic);
-  const admin = planData.members.find((item) => item.isAdmin === true)?.name;
-  const [adminName, setAdminName] = useState<string | null>(admin || null);
-  const [showOptions, setShowOptions] = useState<boolean>(false);
+  const initialAdmin = planData.members.find((item) => item.isAdmin === true);
+  const [admin, setAdmin] = useState<ISelectOption>({ id: initialAdmin?.id, name: initialAdmin?.name });
   const [deletedList, setDeletedList] = useState<number[]>([]);
-
+  const options = planData.members.map((member) => {
+    return { id: member.id, name: member.name };
+  });
   const changePlanInfo = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setPlanInfo((prev) => ({ ...prev, [name]: value }));
@@ -464,36 +410,7 @@ function Setting() {
         <div className="set">
           <ManageAdmin>
             <span>관리자</span>
-            <SelectBoxContainer onClick={() => setShowOptions((prev) => !prev)}>
-              <Selected>{adminName}</Selected>
-              {showOptions && (
-                <SelectOptions>
-                  {planData.members.map((option) => (
-                    <Option
-                      key={option.id}
-                      value={option.name}
-                      onClick={() => {
-                        setAdminName(option.name);
-                      }}
-                    >
-                      {option.name}
-                    </Option>
-                  ))}
-                </SelectOptions>
-              )}
-              <SelectBoxArrowContainer>
-                <SelectBoxArrow
-                  $showOptions={showOptions}
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="11"
-                  height="6"
-                  viewBox="0 0 11 6"
-                  fill="none"
-                >
-                  <path d="M0.291664 0.416748L5.5 5.62508L10.7083 0.416748H0.291664Z" fill="#8993A1" />
-                </SelectBoxArrow>
-              </SelectBoxArrowContainer>
-            </SelectBoxContainer>
+            <SelectBox options={options} value={admin} setValue={setAdmin} />
           </ManageAdmin>
           <ManageAdmin>
             <span>{isPublic ? '플랜을 공개할게요' : '플랜을 공개하지 않아요'}</span>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,8 +16,8 @@ export interface ITask {
   title: string;
   tabId: number;
   labels: number[];
-  assignee: string;
-  assigneeId: number;
+  assignee: string | undefined;
+  assigneeId: number | undefined;
   order: number;
   dateRange: null | string[];
 }
@@ -36,8 +36,8 @@ export interface ITab {
 }
 
 export interface ISelectOption {
-  id: number;
-  name: string;
+  id: number | undefined;
+  name: string | undefined;
 }
 
 export interface IAddTaskModal {


### PR DESCRIPTION
📌 Description
- 설정페이지 ui 구현했습니다.
- 플랜 생성 페이지와 상당히 유사한 구조입니다.
  - 추후에 InputField, 팀원 관리 컴포넌트 등을 공통 컴포넌트로 만들 생각입니다.
- SelectBox를 사용해서 관리자를 지정했습니다.
- 플랜 페이지에서 설정 아이콘 클릭하면 이동하도록 만들었습니다.

⚠️ 주의사항
- SelectBox 사용할 때 props에 value를 추가했습니다. 
  - 관리자의 경우 이미 지정되어 있어 초기 값을 넘겨주기 위해서입니다.
- 설정 페이지의 전체적인 폰트 사이즈를 14px로 사용했는데 보시고 어떠신지(너무 작다 or 괜찮다) 알려주세요.

close #30