### PR TITLE
[#33] 플랜 설정, 생성 페이지 공통 컴포넌트 분리

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const Container = styled.div`
+  label {
+    font-weight: 600;
+  }
+
+  input {
+    display: block;
+    width: 75rem;
+    height: 2.2rem;
+    padding: 0.5rem 0.7rem;
+    margin-top: 0.4rem;
+    border: 1px solid rgb(208, 215, 222);
+    border-radius: 6px;
+    outline: none;
+    background-color: #fafafa;
+    font-size: 14px;
+
+    &.email {
+      width: 600px;
+      margin-top: 0;
+    }
+
+    &::placeholder {
+      font-size: inherit;
+    }
+
+    &:focus {
+      border: 2px solid #64d4ab;
+    }
+  }
+`;
+
+function InputField({ children }: Props) {
+  return <Container>{children}</Container>;
+}
+
+export default InputField;

--- a/src/components/ManageTeam.tsx
+++ b/src/components/ManageTeam.tsx
@@ -15,7 +15,8 @@ interface Props {
 }
 
 const Container = styled.div`
-  min-height: 15rem;
+  width: 600px;
+  min-height: 17.5rem;
   background-color: #fafafa;
   padding: 1rem;
   border: 1px solid rgb(208, 215, 222);
@@ -23,6 +24,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  overflow-y: auto;
 
   color: #939393;
   font-size: 14px;

--- a/src/components/ManageTeam.tsx
+++ b/src/components/ManageTeam.tsx
@@ -15,6 +15,7 @@ interface Props {
 }
 
 const Container = styled.div`
+  min-height: 15rem;
   background-color: #fafafa;
   padding: 1rem;
   border: 1px solid rgb(208, 215, 222);

--- a/src/components/ManageTeam.tsx
+++ b/src/components/ManageTeam.tsx
@@ -1,0 +1,149 @@
+/* eslint-disable react/require-default-props */
+import React from 'react';
+
+import { MdOutlineClose } from 'react-icons/md';
+import styled from 'styled-components';
+import { IMember } from 'types';
+
+interface Props {
+  type: string;
+  newMemberEmailList: string[];
+  existingMembers?: IMember[];
+  deletedExistMemberIdList?: number[];
+  handleDeleteNewMember: (deletedEmail: string) => void;
+  handleDeleteExistMember?: (deletedId: number) => void;
+}
+
+const Container = styled.div`
+  background-color: #fafafa;
+  padding: 1rem;
+  border: 1px solid rgb(208, 215, 222);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  color: #939393;
+  font-size: 14px;
+`;
+
+const List = styled.div`
+  .subTitle {
+    font-weight: 600;
+  }
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+`;
+
+const Item = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .invite {
+    color: #000;
+  }
+
+  .memberInfo {
+    display: flex;
+    flex-direction: column;
+
+    .name {
+      font-weight: 600;
+      color: #000;
+    }
+  }
+
+  .delete {
+    display: flex;
+    align-items: center;
+
+    .pending {
+      margin-right: 1rem;
+      color: #cf2d7b;
+      font-weight: 600;
+    }
+  }
+
+  button {
+    font-weight: 600;
+    color: #939393;
+
+    &.invite {
+      height: fit-content;
+      border: none;
+    }
+
+    &.exist {
+      border-radius: 0.5rem;
+      border: 1px solid #d1d1d1;
+      padding-inline: 0.9rem;
+      height: 2.2rem;
+      transition:
+        color,
+        background-color,
+        border 0.3s cubic-bezier(0.33, 1, 0.68, 1);
+
+      &:hover {
+        background-color: #ff5353;
+        color: #fff;
+        border: none;
+      }
+    }
+  }
+`;
+
+function ManageTeam({
+  type,
+  newMemberEmailList,
+  existingMembers,
+  deletedExistMemberIdList,
+  handleDeleteNewMember,
+  handleDeleteExistMember,
+}: Props) {
+  return (
+    <Container>
+      <List>
+        <span className="subTitle">새로운 팀원</span>
+        <ul>
+          {newMemberEmailList.map((item) => (
+            <Item key={item}>
+              <span className="invite">{item}</span>
+              <button type="button" onClick={() => handleDeleteNewMember(item)} className="invite">
+                <MdOutlineClose size="16" color="#939393" />
+              </button>
+            </Item>
+          ))}
+        </ul>
+      </List>
+      {type === 'setting' && (
+        <List>
+          <span className="subTitle">팀원 현황</span>
+          <ul>
+            {existingMembers?.map((item) => (
+              <Item key={item.id}>
+                <div className="memberInfo">
+                  <span className="name">{item.name}</span>
+                  <span>{item.email}</span>
+                </div>
+                <div className="delete">
+                  {deletedExistMemberIdList?.includes(item.id) && <span className="pending">삭제 예정</span>}
+                  <button type="button" onClick={() => handleDeleteExistMember!(item.id)} className="exist">
+                    {deletedExistMemberIdList?.includes(item.id) ? '되돌리기' : '삭제'}
+                  </button>
+                </div>
+              </Item>
+            ))}
+          </ul>
+        </List>
+      )}
+    </Container>
+  );
+}
+
+export default ManageTeam;

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -7,20 +7,22 @@ import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
 import ToggleSwitch from '@components/ToggleSwitch';
 
-const Wrapper = styled.div`
+const Wrapper = styled.form`
   width: 100vw;
   min-height: 100vh;
   padding: 110px 70px 40px;
-`;
-
-const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 1.5rem;
 `;
 
+const Title = styled.h2`
+  font-size: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgb(216, 222, 228);
+`;
 const BottomContainer = styled.div`
-  width: calc(100vw - 140px);
+  width: 75rem;
   max-height: 450px;
   display: flex;
   align-items: flex-end;
@@ -31,7 +33,7 @@ const ImageContainer = styled.img`
   max-height: 340px;
 `;
 
-const InviteContainer = styled.div`
+const ManageTeamContainer = styled.div`
   width: 45%;
   height: 350px;
   display: flex;
@@ -47,12 +49,14 @@ const InviteContainer = styled.div`
 
 const Button = styled.button`
   align-self: center;
-  width: 216px;
-  height: 50px;
-  border-radius: 8px;
-  color: #fafafa;
+  width: 10rem;
+  font-size: 14px;
+  height: 2.4rem;
+  padding-inline: 1.5rem;
+  border: none;
+  border-radius: 0.5rem;
+  color: #fff;
   background-color: #64d4ab;
-  font-weight: 700;
 `;
 
 const PublicContainer = styled.div`
@@ -107,62 +111,61 @@ function CreatePlan() {
   };
 
   return (
-    <Wrapper>
-      <FormContainer onSubmit={handleSubmit}>
-        <InputField>
-          <label htmlFor="title">
-            플랜 제목
-            <input
-              type="text"
-              id="title"
-              name="title"
-              value={planInfo.title}
-              onChange={changePlanInfo}
-              placeholder="플랜 이름을 알려주세요"
-            />
-          </label>
-        </InputField>
-        <InputField>
-          <label htmlFor="description">
-            플랜 설명
-            <input
-              type="text"
-              id="description"
-              name="description"
-              value={planInfo.description}
-              onChange={changePlanInfo}
-              placeholder="플랜을 설명해주세요"
-            />
-          </label>
-        </InputField>
+    <Wrapper onSubmit={handleSubmit}>
+      <Title>새로운 플랜</Title>
+      <InputField>
+        <label htmlFor="title">
+          플랜 제목
+          <input
+            type="text"
+            id="title"
+            name="title"
+            value={planInfo.title}
+            onChange={changePlanInfo}
+            placeholder="플랜 이름을 알려주세요"
+          />
+        </label>
+      </InputField>
+      <InputField>
+        <label htmlFor="description">
+          플랜 설명
+          <input
+            type="text"
+            id="description"
+            name="description"
+            value={planInfo.description}
+            onChange={changePlanInfo}
+            placeholder="플랜을 설명해주세요"
+          />
+        </label>
+      </InputField>
 
-        <BottomContainer>
-          <InviteContainer>
-            <InputField>
-              <label htmlFor="members">
-                팀원 초대
-                <input
-                  type="email"
-                  id="members"
-                  name="members"
-                  className="email"
-                  onKeyUp={addMember}
-                  placeholder="초대할 팀원의 이메일을 알려주세요"
-                />
-              </label>
-            </InputField>
-            <ManageTeam type="create" newMemberEmailList={memberEmailList} handleDeleteNewMember={deleteMember} />
-          </InviteContainer>
-          <ImageContainer src={boardIllust} alt="member-illust" />
-        </BottomContainer>
+      <BottomContainer>
+        <ManageTeamContainer>
+          <InputField>
+            <label htmlFor="members">
+              팀원 초대
+              <input
+                type="email"
+                id="members"
+                name="members"
+                className="email"
+                onKeyUp={addMember}
+                placeholder="초대할 팀원의 이메일을 알려주세요"
+              />
+            </label>
+          </InputField>
+          <ManageTeam type="create" newMemberEmailList={memberEmailList} handleDeleteNewMember={deleteMember} />
+        </ManageTeamContainer>
+        <ImageContainer src={boardIllust} alt="member-illust" />
+      </BottomContainer>
 
-        <PublicContainer>
-          <ToggleSwitch isPublic={isPublic} onChange={togglePublic} />
-          <p> {isPublic ? '플랜을 공개합니다.' : '플랜을 공개하지 않습니다.'}</p>
-        </PublicContainer>
+      <PublicContainer>
+        <ToggleSwitch isPublic={isPublic} onChange={togglePublic} />
+        <p> {isPublic ? '플랜을 공개합니다.' : '플랜을 공개하지 않습니다.'}</p>
+      </PublicContainer>
 
-        <Button type="submit">생성하기</Button>
-      </FormContainer>
+      <Button type="submit">생성하기</Button>
     </Wrapper>
   );
 }

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 
-import { MdOutlineClose } from 'react-icons/md';
 import styled from 'styled-components';
 
 import boardIllust from '@assets/images/boardIllust.svg';
+import ManageTeam from '@components/ManageTeam';
 import ToggleSwitch from '@components/ToggleSwitch';
 
 const Wrapper = styled.div`
@@ -60,28 +60,6 @@ const InviteContainer = styled.div`
   p.label {
     font-size: 18px;
     font-weight: bold;
-  }
-`;
-
-const MemberList = styled.ul`
-  width: 100%;
-  height: 300px;
-  border-radius: 8px;
-  padding: 1.5rem 1rem;
-  background-color: #fafafa;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  overflow-y: scroll;
-`;
-
-const MemberItem = styled.li`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  button {
-    background-color: inherit;
   }
 `;
 
@@ -190,16 +168,7 @@ function CreatePlan() {
                 />
               </label>
             </InputField>
-            <MemberList>
-              {memberEmailList.map((item) => (
-                <MemberItem key={item}>
-                  {item}
-                  <button type="button" onClick={() => deleteMember(item)}>
-                    <MdOutlineClose size="18" color="red" />
-                  </button>
-                </MemberItem>
-              ))}
-            </MemberList>
+            <ManageTeam type="create" newMemberEmailList={memberEmailList} handleDeleteNewMember={deleteMember} />
           </InviteContainer>
           <ImageContainer src={boardIllust} alt="member-illust" />
         </BottomContainer>

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import boardIllust from '@assets/images/boardIllust.svg';
+import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
 import ToggleSwitch from '@components/ToggleSwitch';
 
@@ -16,25 +17,6 @@ const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
   gap: 32px;
-`;
-
-const InputField = styled.div`
-  label {
-    font-weight: 600;
-  }
-
-  input {
-    display: block;
-    width: 100%;
-    padding: 1rem;
-    margin-top: 8px;
-    border-radius: 8px;
-    background-color: #fafafa;
-
-    &:focus {
-      outline: 1px solid #b8b8b84f;
-    }
-  }
 `;
 
 const BottomContainer = styled.div`
@@ -163,6 +145,7 @@ function CreatePlan() {
                   type="email"
                   id="members"
                   name="members"
+                  className="email"
                   onKeyUp={addMember}
                   placeholder="초대할 팀원의 이메일을 알려주세요"
                 />

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 
-import { MdOutlineClose } from 'react-icons/md';
+// import { MdOutlineClose } from 'react-icons/md';
 import styled from 'styled-components';
 import { ISelectOption } from 'types';
 
+import ManageTeam from '@components/ManageTeam';
 import SelectBox from '@components/SelectBox';
 import ToggleSwitch from '@components/ToggleSwitch';
 
@@ -59,7 +60,7 @@ const InputField = styled.div`
   }
 `;
 
-const ManageTeam = styled.div`
+const ManageTeamContainer = styled.div`
   width: 600px;
   display: flex;
   flex-direction: column;
@@ -67,90 +68,6 @@ const ManageTeam = styled.div`
 
   h3 {
     font-weight: 600;
-  }
-`;
-
-const ManageTeamContainer = styled.div`
-  background-color: #fafafa;
-  padding: 1rem;
-  border: 1px solid rgb(208, 215, 222);
-  border-radius: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-
-  color: #939393;
-  font-size: 14px;
-`;
-
-const MemberList = styled.div`
-  .subTitle {
-    font-weight: 600;
-  }
-
-  ul {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-  }
-`;
-
-const MemberItem = styled.li`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .invite {
-    color: #000;
-  }
-
-  .memberInfo {
-    display: flex;
-    flex-direction: column;
-
-    .name {
-      font-weight: 600;
-      color: #000;
-    }
-  }
-
-  .delete {
-    display: flex;
-    align-items: center;
-
-    .pending {
-      margin-right: 1rem;
-      color: #cf2d7b;
-      font-weight: 600;
-    }
-  }
-
-  button {
-    font-weight: 600;
-    color: #939393;
-
-    &.invite {
-      height: fit-content;
-      border: none;
-    }
-
-    &.exist {
-      border-radius: 0.5rem;
-      border: 1px solid #d1d1d1;
-      padding-inline: 0.9rem;
-      height: 2.2rem;
-      transition:
-        color,
-        background-color,
-        border 0.3s cubic-bezier(0.33, 1, 0.68, 1);
-
-      &:hover {
-        background-color: #ff5353;
-        color: #fff;
-        border: none;
-      }
-    }
   }
 `;
 
@@ -372,7 +289,7 @@ function Setting() {
           />
         </label>
       </InputField>
-      <ManageTeam>
+      <ManageTeamContainer>
         <h3>팀원 관리</h3>
         <InputField>
           <input
@@ -384,41 +301,15 @@ function Setting() {
             placeholder="초대할 팀원의 이메일을 알려주세요"
           />
         </InputField>
-        <ManageTeamContainer>
-          <MemberList>
-            <span className="subTitle">새로운 팀원</span>
-            <ul>
-              {newMemberEmailList.map((item) => (
-                <MemberItem key={item}>
-                  <span className="invite">{item}</span>
-                  <button type="button" onClick={() => handleDeleteNewMember(item)} className="invite">
-                    <MdOutlineClose size="16" color="#939393" />
-                  </button>
-                </MemberItem>
-              ))}
-            </ul>
-          </MemberList>
-          <MemberList>
-            <span className="subTitle">팀원 현황</span>
-            <ul>
-              {planData.members.map((item) => (
-                <MemberItem key={item.id}>
-                  <div className="memberInfo">
-                    <span className="name">{item.name}</span>
-                    <span>{item.email}</span>
-                  </div>
-                  <div className="delete">
-                    {deletedExistMemberIdList.includes(item.id) && <span className="pending">삭제 예정</span>}
-                    <button type="button" onClick={() => handleDeleteExistMember(item.id)} className="exist">
-                      {deletedExistMemberIdList.includes(item.id) ? '되돌리기' : '삭제'}
-                    </button>
-                  </div>
-                </MemberItem>
-              ))}
-            </ul>
-          </MemberList>
-        </ManageTeamContainer>
-      </ManageTeam>
+        <ManageTeam
+          type="setting"
+          newMemberEmailList={newMemberEmailList}
+          existingMembers={planData.members}
+          deletedExistMemberIdList={deletedExistMemberIdList}
+          handleDeleteNewMember={handleDeleteNewMember}
+          handleDeleteExistMember={handleDeleteExistMember}
+        />
+      </ManageTeamContainer>
       <ImportantSetting>
         <h3>중요 설정 변경</h3>
         <SettingItem>

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 
-// import { MdOutlineClose } from 'react-icons/md';
 import styled from 'styled-components';
 import { ISelectOption } from 'types';
 
+import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
 import SelectBox from '@components/SelectBox';
 import ToggleSwitch from '@components/ToggleSwitch';
@@ -26,38 +26,6 @@ const Title = styled.h2`
   font-size: 1.5rem;
   padding-bottom: 0.5rem;
   border-bottom: 1px solid rgb(216, 222, 228);
-`;
-
-const InputField = styled.div`
-  label {
-    font-weight: 600;
-  }
-
-  input {
-    display: block;
-    width: 75rem;
-    height: 2.2rem;
-    padding: 0.5rem 0.7rem;
-    margin-top: 0.4rem;
-    border: 1px solid rgb(208, 215, 222);
-    border-radius: 6px;
-    outline: none;
-    background-color: #fafafa;
-    font-size: 14px;
-
-    &.email {
-      width: 600px;
-      margin-top: 0;
-    }
-
-    &::placeholder {
-      font-size: inherit;
-    }
-
-    &:focus {
-      border: 2px solid #64d4ab;
-    }
-  }
 `;
 
 const ManageTeamContainer = styled.div`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export interface IMember {
   name: string;
   imgUrl?: string;
   isAdmin: boolean;
+  email?: string;
 }
 
 export interface ITab {


### PR DESCRIPTION
📌 Description
- ManageTeam, InputField 컴포넌트를 분리했습니다.
- 두 페이지의 스타일링을 일관성있게 맞췄습니다.

⚠️ 주의사항
- 분리만 해서 큰 고민 사항은 없습니다.
- 그런데 optional type에 대한 eslint 타입 에러를 매번 /* eslint-disable react/require-default-props */를 추가해서 해결하는데 이게 점점 많아지니까 조금 찜찜해서요. 좀 더 깔끔하게 해결할 방법을 찾아볼 생각입니다. 

close #33