### PR TITLE
[#70] 할 일 삭제 및 플랜, 설정 페이지 모달 연결

### DIFF
--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -1,15 +1,16 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { useState } from 'react';
 
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-import { ILabel, ISelectOption, ITask } from 'types';
+import { IAddTaskModal, ILabel, ISelectOption, ITask } from 'types';
 
 import { ReactComponent as DeadlineDate } from '@assets/images/deadlineCheck.svg';
 import { ReactComponent as StartDate } from '@assets/images/startDate.svg';
 import LabelInput from '@components/LabelInput';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
-import { membersState, modalState } from '@recoil/atoms';
+import useModal from '@hooks/useModal';
+import { membersState, modalDataState } from '@recoil/atoms';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -100,12 +101,7 @@ const DeadlineField = styled.div`
   }
 `;
 
-interface Props {
-  addTaskHandler: Dispatch<SetStateAction<Record<number, ITask[]>>>;
-  onClose: () => void;
-}
-
-export default function AddTaskModal({ addTaskHandler, onClose }: Props) {
+export default function AddTaskModal() {
   const today = new Date();
 
   const members = useRecoilValue(membersState);
@@ -117,7 +113,8 @@ export default function AddTaskModal({ addTaskHandler, onClose }: Props) {
   );
   const [endDate, setEndDate] = useState<string>(startDate);
   const [selectedLabels, setSelectedLabels] = useState<ILabel[]>([]);
-  const modalInfo = useRecoilValue(modalState);
+  const modalData = useRecoilValue(modalDataState) as IAddTaskModal;
+  const { closeModal } = useModal();
 
   const options = members.map((member) => {
     return { id: member.id, name: member.name };
@@ -144,21 +141,21 @@ export default function AddTaskModal({ addTaskHandler, onClose }: Props) {
       // TODO: 백엔드로 할 일 추가 요청 후 id 받아와야 함
       id: Math.floor(Math.random() * 1000) + 5,
       title: taskName,
-      tabId: modalInfo.tabId,
+      tabId: modalData.tabId,
       labels: selectedLabels.map((label) => label.id),
       assignee: assignee.name,
       assigneeId: assignee.id,
-      order: modalInfo.taskOrder,
+      order: modalData.taskOrder,
       dateRange: checkDeadline ? [startDate, endDate] : null,
     };
     // Plan 페이지 tasks 상태에 반영
-    addTaskHandler((prev) => {
+    modalData.addTaskHandler((prev) => {
       const newTasks = { ...prev };
-      newTasks[modalInfo.tabId].push(newTask);
+      newTasks[modalData.tabId].push(newTask);
       return newTasks;
     });
     // 모달 닫기
-    onClose();
+    closeModal();
   };
 
   return (

--- a/src/components/Modal/ExitPlan.tsx
+++ b/src/components/Modal/ExitPlan.tsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-import { ISelectOption } from 'types';
+import { IExitPlanModal, ISelectOption } from 'types';
 
 import { ModalButton, ModalButtonContainer, ModalDescription } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
-import { membersState } from '@recoil/atoms';
+import useModal from '@hooks/useModal';
+import { membersState, modalDataState } from '@recoil/atoms';
 
 const SelectAdminContainer = styled.div`
   display: flex;
@@ -17,16 +18,11 @@ const SelectAdminContainer = styled.div`
 const SelectAdminText = styled.p`
   color: #76808e;
 `;
-
-interface ExitPlanProps {
-  description: string;
-  requestAPI: () => void;
-  onClose: () => void;
-}
-
 // 관리자가 플랜을 나갈떄 사용할 모달
-export default function ExitPlanModal({ description, requestAPI, onClose }: ExitPlanProps) {
+export default function ExitPlanModal() {
   const members = useRecoilValue(membersState);
+  const modalData = useRecoilValue(modalDataState) as IExitPlanModal;
+  const { closeModal } = useModal();
   const [admin, setAdmin] = useState<ISelectOption>({ id: -1, name: '' });
   const options = members.map((member) => {
     return { id: member.id, name: member.name };
@@ -37,16 +33,16 @@ export default function ExitPlanModal({ description, requestAPI, onClose }: Exit
 
   return (
     <>
-      <ModalDescription>{description}</ModalDescription>
+      <ModalDescription>{modalData.description}</ModalDescription>
       <SelectAdminContainer>
         <SelectAdminText>관리자 지정</SelectAdminText>
         <SelectBox options={options} setValue={setAdmin} />
       </SelectAdminContainer>
       <ModalButtonContainer>
-        <ModalButton type="button" onClick={requestAPI}>
+        <ModalButton type="button" onClick={modalData.requestAPI}>
           예
         </ModalButton>
-        <ModalButton type="button" onClick={onClose}>
+        <ModalButton type="button" onClick={closeModal}>
           아니오
         </ModalButton>
       </ModalButtonContainer>

--- a/src/components/Modal/Normal.tsx
+++ b/src/components/Modal/Normal.tsx
@@ -12,11 +12,16 @@ export default function NormalModal() {
   const modalData = useRecoilValue(modalDataState) as INormalModal;
   const { closeModal } = useModal();
 
+  const onClickHandler = () => {
+    modalData.requestAPI();
+    closeModal();
+  };
+
   return (
     <>
       <ModalDescription>{modalData.description}</ModalDescription>
       <ModalButtonContainer>
-        <ModalButton type="button" onClick={modalData.requestAPI}>
+        <ModalButton type="button" onClick={onClickHandler}>
           예
         </ModalButton>
         <ModalButton type="button" onClick={closeModal}>

--- a/src/components/Modal/Normal.tsx
+++ b/src/components/Modal/Normal.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 
-import { ModalButton, ModalButtonContainer, ModalDescription } from '@components/Modal/CommonModalStyles';
+import { useRecoilValue } from 'recoil';
+import { INormalModal } from 'types';
 
-interface NormalProps {
-  description: string;
-  requestAPI: () => void;
-  onClose: () => void;
-}
+import { ModalButton, ModalButtonContainer, ModalDescription } from '@components/Modal/CommonModalStyles';
+import useModal from '@hooks/useModal';
+import { modalDataState } from '@recoil/atoms';
 
 // 일반 모달
-export default function NormalModal({ description, requestAPI, onClose }: NormalProps) {
+export default function NormalModal() {
+  const modalData = useRecoilValue(modalDataState) as INormalModal;
+  const { closeModal } = useModal();
+
   return (
     <>
-      <ModalDescription>{description}</ModalDescription>
+      <ModalDescription>{modalData.description}</ModalDescription>
       <ModalButtonContainer>
-        <ModalButton type="button" onClick={requestAPI}>
+        <ModalButton type="button" onClick={modalData.requestAPI}>
           예
         </ModalButton>
-        <ModalButton type="button" onClick={onClose}>
+        <ModalButton type="button" onClick={closeModal}>
           아니오
         </ModalButton>
       </ModalButtonContainer>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,12 +1,15 @@
-import React, { Dispatch, SetStateAction, useEffect } from 'react';
+/* eslint-disable react/jsx-no-useless-fragment */
+import React, { useEffect } from 'react';
 
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-import { ITask } from 'types';
 
 import AddTaskModal from '@components/Modal/AddTask';
 import ExitPlanModal from '@components/Modal/ExitPlan';
 import NormalModal from '@components/Modal/Normal';
 import ModalPortal from '@components/Modal/Portal';
+import useModal from '@hooks/useModal';
+import { modalState } from '@recoil/atoms';
 
 const ModalOverlay = styled.div`
   position: absolute;
@@ -39,21 +42,14 @@ const ModalContainer = styled.div`
   justify-content: space-between;
 `;
 
-type ModalType = 'none' | 'normal' | 'exitPlan' | 'addTask';
+export default function Modal() {
+  const { isOpen, type } = useRecoilValue(modalState);
+  const { closeModal } = useModal();
 
-interface Props {
-  type: ModalType;
-  description?: string;
-  requestAPI: () => void;
-  onClose: () => void;
-  addTaskHandler?: Dispatch<SetStateAction<Record<number, ITask[]>>>;
-}
-
-export default function Modal({ type, description, requestAPI, onClose, addTaskHandler }: Props) {
   useEffect(() => {
     const keyDownEscCloseModal = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onClose();
+        closeModal();
       }
     };
     window.addEventListener('keydown', keyDownEscCloseModal);
@@ -61,21 +57,21 @@ export default function Modal({ type, description, requestAPI, onClose, addTaskH
   }, []);
 
   return (
-    <ModalPortal>
-      <ModalOverlay onClick={onClose}>
-        <ModalWrapper type={type} onClick={(e) => e.stopPropagation()}>
-          <ModalContainer>
-            {type === 'normal' && description && (
-              <NormalModal description={description} requestAPI={requestAPI} onClose={onClose} />
-            )}
-            {type === 'exitPlan' && description && (
-              <ExitPlanModal description={description} requestAPI={requestAPI} onClose={onClose} />
-            )}
-            {addTaskHandler && type === 'addTask' && <AddTaskModal addTaskHandler={addTaskHandler} onClose={onClose} />}
-          </ModalContainer>
-        </ModalWrapper>
-      </ModalOverlay>
-    </ModalPortal>
+    <>
+      {isOpen && (
+        <ModalPortal>
+          <ModalOverlay onClick={closeModal}>
+            <ModalWrapper type={type} onClick={(e) => e.stopPropagation()}>
+              <ModalContainer>
+                {type === 'normal' && <NormalModal />}
+                {type === 'exitPlan' && <ExitPlanModal />}
+                {type === 'addTask' && <AddTaskModal />}
+              </ModalContainer>
+            </ModalWrapper>
+          </ModalOverlay>
+        </ModalPortal>
+      )}
+    </>
   );
 }
 

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -19,6 +19,7 @@ interface ITabProps {
   onDeleteTab: () => void;
   onSaveTitle: (title: string) => void;
   onClickHandler: () => void;
+  onRemoveTask: (tabId: number, taskId: number) => void;
 }
 
 interface ITabHeaderProps {
@@ -32,6 +33,7 @@ interface ITaskContainerProps {
   id?: number;
   tasks?: ITask[];
   onClickHandler?: () => void;
+  onRemoveTask?: (tabId: number, taskId: number) => void;
 }
 
 const Wrapper = styled.li`
@@ -160,14 +162,17 @@ function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: ITabHeaderProps) 
   );
 }
 
-export function TasksContainer({ id, tasks, onClickHandler }: ITaskContainerProps) {
+export function TasksContainer({ id, tasks, onClickHandler, onRemoveTask }: ITaskContainerProps) {
   return (
     <Container>
       {id ? (
         <Droppable droppableId={id.toString()}>
           {(provided) => (
             <TaskList {...provided.droppableProps} ref={provided.innerRef}>
-              {tasks?.map((task, index) => <TaskItem key={task.id} task={task} index={index} />)}
+              {tasks?.map((task, index) => (
+                // TODO: void 함수를 주는 것 외에 다른 방식을 생각해볼 필요가 있음
+                <TaskItem key={task.id} task={task} index={index} onRemoveTask={onRemoveTask || (() => {})} />
+              ))}
               {provided.placeholder}
             </TaskList>
           )}
@@ -185,11 +190,11 @@ export function TasksContainer({ id, tasks, onClickHandler }: ITaskContainerProp
   );
 }
 
-export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSaveTitle }: ITabProps) {
+export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSaveTitle, onRemoveTask }: ITabProps) {
   return (
     <Wrapper className="dnd-tab" data-index={index} data-id={id}>
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
-      <TasksContainer id={id} tasks={tasks} onClickHandler={onClickHandler} />
+      <TasksContainer id={id} tasks={tasks} onClickHandler={onClickHandler} onRemoveTask={onRemoveTask} />
     </Wrapper>
   );
 }

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -2,14 +2,17 @@
 /* eslint-disable react/no-unused-prop-types */
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, Dispatch, SetStateAction } from 'react';
 
 import { Droppable } from 'react-beautiful-dnd';
+import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { ITask } from 'types';
 
 import Dropdown from '@components/Dropdown';
 import TaskItem from '@components/TaskItem';
+import useModal from '@hooks/useModal';
+import { modalDataState } from '@recoil/atoms';
 
 interface ITabProps {
   id: number;
@@ -18,7 +21,7 @@ interface ITabProps {
   tasks: ITask[];
   onDeleteTab: () => void;
   onSaveTitle: (title: string) => void;
-  onClickHandler: () => void;
+  onAddTask: Dispatch<SetStateAction<Record<number, ITask[]>>>;
   onRemoveTask: (tabId: number, taskId: number) => void;
 }
 
@@ -32,7 +35,7 @@ interface ITabHeaderProps {
 interface ITaskContainerProps {
   id?: number;
   tasks?: ITask[];
-  onClickHandler?: () => void;
+  onAddTask?: Dispatch<SetStateAction<Record<number, ITask[]>>>;
   onRemoveTask?: (tabId: number, taskId: number) => void;
 }
 
@@ -162,7 +165,20 @@ function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: ITabHeaderProps) 
   );
 }
 
-export function TasksContainer({ id, tasks, onClickHandler, onRemoveTask }: ITaskContainerProps) {
+export function TasksContainer({ id, tasks, onAddTask, onRemoveTask }: ITaskContainerProps) {
+  const { openModal } = useModal();
+  const setModalData = useSetRecoilState(modalDataState);
+
+  const handleAddTask = () => {
+    if (!tasks || !id || !onAddTask) return;
+    setModalData({
+      tabId: id,
+      taskOrder: tasks ? tasks.length : 0,
+      addTaskHandler: onAddTask,
+    });
+    openModal('addTask');
+  };
+
   return (
     <Container>
       {id ? (
@@ -181,7 +197,7 @@ export function TasksContainer({ id, tasks, onClickHandler, onRemoveTask }: ITas
         <TaskList />
       )}
       <Interactions>
-        <AddButton type="button" className="add" onClick={onClickHandler}>
+        <AddButton type="button" className="add" onClick={handleAddTask}>
           Add Item
         </AddButton>
         <TabDragBar type="button" draggable className="dnd-item" />
@@ -190,11 +206,11 @@ export function TasksContainer({ id, tasks, onClickHandler, onRemoveTask }: ITas
   );
 }
 
-export function Tab({ id, index, title, tasks, onDeleteTab, onClickHandler, onSaveTitle, onRemoveTask }: ITabProps) {
+export function Tab({ id, index, title, tasks, onDeleteTab, onSaveTitle, onAddTask, onRemoveTask }: ITabProps) {
   return (
     <Wrapper className="dnd-tab" data-index={index} data-id={id}>
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
-      <TasksContainer id={id} tasks={tasks} onClickHandler={onClickHandler} onRemoveTask={onRemoveTask} />
+      <TasksContainer id={id} tasks={tasks} onAddTask={onAddTask} onRemoveTask={onRemoveTask} />
     </Wrapper>
   );
 }

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -5,10 +5,12 @@ import React from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import { IoClose, IoInfinite } from 'react-icons/io5';
 import { PiClockFill } from 'react-icons/pi';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
-import { ITask } from 'types';
+import { INormalModal, ITask } from 'types';
 
+import useModal from '@hooks/useModal';
+import { modalDataState } from '@recoil/atoms';
 import { filteredLabelsSelector, memberSelector } from '@recoil/selectors';
 import { hashStringToColor } from '@utils';
 
@@ -92,17 +94,23 @@ interface Props {
 export default function TaskItem({ task, index, onRemoveTask }: Props) {
   const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
   const assignee = useRecoilValue(memberSelector(task.assigneeId!));
+  const setModalData = useSetRecoilState(modalDataState);
+  const { openModal } = useModal();
+
+  const removeTaskHandler = () => {
+    const requestAPI = () => {
+      // TODO: 서버에 태스크 삭제 요청
+      onRemoveTask(task.tabId, task.id);
+    };
+    setModalData({ description: `"${task.title}"을 삭제할까요?`, requestAPI } as INormalModal);
+    openModal('normal');
+  };
 
   return (
     <Draggable draggableId={task.id.toString()} index={index}>
       {(provided) => (
         <ItemContainer {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef}>
-          <button
-            type="button"
-            onClick={() => {
-              onRemoveTask(task.tabId, task.id);
-            }}
-          >
+          <button type="button" onClick={removeTaskHandler}>
             <IoClose size={20} />
           </button>
           <p id="task-title">{task.title}</p>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -86,9 +86,10 @@ const DateField = styled.div`
 interface Props {
   task: ITask;
   index: number;
+  onRemoveTask: (tabId: number, taskId: number) => void;
 }
 
-export default function TaskItem({ task, index }: Props) {
+export default function TaskItem({ task, index, onRemoveTask }: Props) {
   const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
   const assignee = useRecoilValue(memberSelector(task.assigneeId!));
 
@@ -96,7 +97,12 @@ export default function TaskItem({ task, index }: Props) {
     <Draggable draggableId={task.id.toString()} index={index}>
       {(provided) => (
         <ItemContainer {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef}>
-          <button type="button">
+          <button
+            type="button"
+            onClick={() => {
+              onRemoveTask(task.tabId, task.id);
+            }}
+          >
             <IoClose size={20} />
           </button>
           <p id="task-title">{task.title}</p>

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,12 +1,30 @@
-import { useState } from 'react';
+import { useCallback } from 'react';
 
-import Modal from '@components/Modal';
+import { useRecoilState } from 'recoil';
+import { TModalType } from 'types';
 
-type ModalType = 'none' | 'normal' | 'exitPlan' | 'addTask' | 'editTask';
+import { modalState } from '@recoil/atoms';
 
 export default function useModal() {
-  const [showModal, setShowModal] = useState<ModalType>('none');
-  const openModal = (modalType: ModalType) => setShowModal(modalType);
-  const closeModal = () => setShowModal('none');
-  return { Modal, showModal, openModal, closeModal };
+  const [modalInfo, setModalInfo] = useRecoilState(modalState);
+
+  const closeModal = useCallback(
+    () =>
+      setModalInfo({
+        isOpen: false,
+        type: 'none',
+      }),
+    [setModalInfo],
+  );
+
+  const openModal = useCallback(
+    (modalType: TModalType) =>
+      setModalInfo({
+        isOpen: true,
+        type: modalType,
+      }),
+    [setModalInfo],
+  );
+
+  return { modalInfo, closeModal, openModal };
 }

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -14,9 +14,9 @@ import { ITask, ITab, IMember, ILabel } from 'types';
 import { getPlanInfo } from '@apis';
 import LabelFilter from '@components/LabelFilter';
 import MemberFilter from '@components/MemberFilter';
+import Modal from '@components/Modal';
 import { Tab, TasksContainer } from '@components/Tab';
-import useModal from '@hooks/useModal';
-import { labelsState, membersState, modalState } from '@recoil/atoms';
+import { labelsState, membersState } from '@recoil/atoms';
 import registDND, { IDropEvent } from '@utils/drag';
 
 interface IPlan {
@@ -172,12 +172,11 @@ function Plan() {
   const [newTabTitle, setNewTabTitle] = useState<string>('');
   const [isAddingTab, setIsAddingTab] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const { Modal, showModal, openModal, closeModal } = useModal();
+
   const [selectedLabels, setSelectedLabel] = useState<number[]>([]);
   const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
   const setMembers = useSetRecoilState(membersState);
   const setLabels = useSetRecoilState(labelsState);
-  const setModalInfo = useSetRecoilState(modalState);
 
   const navigate = useNavigate();
 
@@ -446,11 +445,8 @@ function Plan() {
                     title={item.title}
                     onDeleteTab={() => handleDeleteTab(item.id)}
                     tasks={tasks[item.id]}
-                    onClickHandler={() => {
-                      setModalInfo({ tabId: item.id, taskOrder: tasks[item.id] ? tasks[item.id].length : 0 });
-                      openModal('addTask');
-                    }}
                     onSaveTitle={handleSaveTabTitle}
+                    onAddTask={setTasks}
                     onRemoveTask={handleDeleteTask}
                   />
                 );
@@ -466,11 +462,7 @@ function Plan() {
                     onKeyDown={handleInputKeyDown}
                   />
                   {/* TODO 탭 추가하다 취소하는 버튼 추가 */}
-                  <TasksContainer
-                    onClickHandler={() => {
-                      openModal('addTask');
-                    }}
-                  />
+                  <TasksContainer />
                 </TabWrapper>
               )}
             </TabContainer>
@@ -480,16 +472,7 @@ function Plan() {
           </AddTapButton>
         </TabGroup>
       </MainContainer>
-      {showModal === 'addTask' && (
-        <Modal
-          type={showModal}
-          onClose={closeModal}
-          addTaskHandler={setTasks}
-          requestAPI={() => {
-            // TODO: 할 일 추가 API 입력
-          }}
-        />
-      )}
+      <Modal />
     </Wrapper>
   );
 }

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -30,6 +30,18 @@ interface IPlan {
   tasks: ITask[];
 }
 
+interface IDragDropResult {
+  source: {
+    droppableId: string;
+    index: number;
+  };
+  destination: {
+    droppableId: string;
+    index: number;
+  };
+  draggableId: string;
+}
+
 const Wrapper = styled.main`
   width: 100vw;
   min-height: 100vh;
@@ -328,18 +340,6 @@ function Plan() {
     // TODO : 서버로 planId, tabId, title로 title 수정 요청 날리기
     return title;
   };
-
-  interface IDragDropResult {
-    source: {
-      droppableId: string;
-      index: number;
-    };
-    destination: {
-      droppableId: string;
-      index: number;
-    };
-    draggableId: string;
-  }
 
   const onDragEnd = (result: IDragDropResult) => {
     const { destination, source } = result;

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -308,6 +308,18 @@ function Plan() {
     // TODO newTabTitle===""일떄 enter를 누르면 탭 추가 취소
   };
 
+  const handleDeleteTask = (tabId: number, taskId: number) => {
+    if (tasks) {
+      let idx = 0;
+      while (tasks[tabId][idx] && tasks[tabId][idx].id !== taskId) idx += 1;
+      setTasks((prev) => {
+        const newTasks = { ...prev };
+        newTasks[tabId].splice(idx, 1);
+        return newTasks;
+      });
+    }
+  };
+
   const handleDeleteTab = (tabId: number) => {
     if (plan) {
       const updatedTabOrder = plan.tabOrder.filter((item) => item !== tabId);
@@ -439,6 +451,7 @@ function Plan() {
                       openModal('addTask');
                     }}
                     onSaveTitle={handleSaveTabTitle}
+                    onRemoveTask={handleDeleteTask}
                   />
                 );
               })}

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,12 +1,16 @@
 import React, { useState } from 'react';
 
+import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
-import { ISelectOption } from 'types';
+import { INormalModal, ISelectOption } from 'types';
 
 import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
+import Modal from '@components/Modal';
 import SelectBox from '@components/SelectBox';
 import ToggleSwitch from '@components/ToggleSwitch';
+import useModal from '@hooks/useModal';
+import { modalDataState } from '@recoil/atoms';
 
 interface IPlanInfo {
   title: string;
@@ -185,6 +189,8 @@ function Setting() {
   const [deletedExistMemberIdList, setDeletedExistMemberIdList] = useState<number[]>([]);
   const [admin, setAdmin] = useState<ISelectOption>({ id: initialAdmin?.id, name: initialAdmin?.name });
   const [isPublic, setIsPublic] = useState<boolean>(planData.isPublic);
+  const setModalData = useSetRecoilState(modalDataState);
+  const { openModal } = useModal();
 
   const options = planData.members.map((member) => {
     return { id: member.id, name: member.name };
@@ -221,11 +227,19 @@ function Setting() {
   };
 
   const handleDeletePlan = () => {
-    // TODO: 서버에 플랜 삭제 요청
+    const requestAPI = () => {
+      // TODO: 서버에 플랜 삭제 요청
+    };
+    setModalData({ description: `플랜을 정말 삭제하시겠어요?`, requestAPI } as INormalModal);
+    openModal('normal');
   };
 
   const handleSavePlan = () => {
-    // TODO: 서버에 플랜 수정 요청
+    const requestAPI = () => {
+      // TODO: 서버에 플랜 수정 요청
+    };
+    setModalData({ description: `변경사항을 저장하시겠어요?`, requestAPI } as INormalModal);
+    openModal('normal');
   };
 
   return (
@@ -297,6 +311,7 @@ function Setting() {
           변경사항 저장
         </Button>
       </ButtonContainer>
+      <Modal />
     </Wrapper>
   );
 }

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-import { IAddTaskModal, ILabel, IMember } from 'types';
+import { ILabel, IMember, IModalInfo, TModalData } from 'types';
 
 export const membersState = atom<IMember[]>({
   key: 'members',
@@ -11,7 +11,12 @@ export const labelsState = atom<ILabel[]>({
   default: [],
 });
 
-export const modalState = atom<IAddTaskModal>({
+export const modalState = atom<IModalInfo>({
   key: 'modal',
-  default: { tabId: 0, taskOrder: 0 },
+  default: { isOpen: false, type: 'none' },
+});
+
+export const modalDataState = atom<TModalData>({
+  key: 'modalData',
+  default: null,
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from 'react';
+
 export interface ITaskInfo {
   name: string;
   id: string;
@@ -41,7 +43,24 @@ export interface ISelectOption {
   name: string | undefined;
 }
 
+export interface IModalInfo {
+  isOpen: boolean;
+  type: TModalType;
+}
+
+export interface INormalModal {
+  description: string;
+  requestAPI: () => void;
+}
+
+export interface IExitPlanModal extends INormalModal {}
+
 export interface IAddTaskModal {
   tabId: number;
   taskOrder: number;
+  addTaskHandler: Dispatch<SetStateAction<Record<number, ITask[]>>>;
 }
+
+export type TModalType = 'none' | 'normal' | 'exitPlan' | 'addTask' | 'editTask';
+
+export type TModalData = null | INormalModal | IExitPlanModal | IAddTaskModal;


### PR DESCRIPTION
## 📌 Description
- 모달 컴포넌트 전체를 Recoil을 이용해 리팩토링하였습니다.
  - 사용이 훨씬 쉬워졌어요!
  - 원하는 곳에 `<Modal />`을 선언하고, 위에서 `useModal` hook을 이용해 편리하게 열었다 닫을 수 있습니다.
  - 모달에 필요한 정보는 `modalDataState`를 업데이트하여 전달할 수 있습니다.
- 할 일 삭제 기능을 구현했습니다.
- 설정 페이지에 필요한 모달을 연결했습니다.

## ⚠️ 주의사항
- 중요 설정 사항을 위쪽으로 올려야 할 것 같습니다. 관리자 설정시 사람이 많아지면 옵션이 짤릴것 같아요 ㅠ
- 새로운 멤버를 추가할 때 정규식으로 이메일을 검사하는 로직이 있으면 좋을 것 같다는 생각이 들었어요
- 멤버 삭제 후 되돌리기 호버시 크기가 달라져서 `삭제예정`이라는 텍스트가 쬐끔 움직이는데 움직이지 않도록 수정할 필요가 있어보입니다!

close #70 