### PR TITLE
[#73] 할 일 수정 모달 구현

### DIFF
--- a/public/dummy/planInfo-1.json
+++ b/public/dummy/planInfo-1.json
@@ -55,7 +55,8 @@
             "tabId": 3,
             "labels": [3],
             "assigneeId": 3,
-            "order": 0
+            "order": 0,
+            "description": ""
          },
          {
             "id": 2,
@@ -63,7 +64,8 @@
             "tabId": 1,
             "labels": [1],
             "assigneeId": 3,
-            "order": 0
+            "order": 0,
+            "description": ""
          },
          {
             "id": 3,
@@ -71,7 +73,8 @@
             "tabId": 2,
             "labels": [1],
             "assigneeId":4,
-            "order": 0
+            "order": 0,
+            "description": ""
          },
          {
             "id": 4,
@@ -79,7 +82,8 @@
             "tabId": 2,
             "labels": [2],
             "assigneeId": 1,
-            "order": 1
+            "order": 1,
+            "description": ""
          }
    ]
 }

--- a/src/components/DateRange.tsx
+++ b/src/components/DateRange.tsx
@@ -1,0 +1,109 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { ReactComponent as DeadlineDate } from '@assets/images/deadlineCheck.svg';
+import { ReactComponent as StartDate } from '@assets/images/startDate.svg';
+
+const DeadlineField = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .deadline-label {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+
+    .label-name {
+      color: #76808e;
+    }
+  }
+
+  .deadline-prop {
+    padding-left: 0.5rem;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: center;
+
+    .prop-name-container {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      justify-content: center;
+
+      .prop-name {
+        font-size: 0.8rem;
+      }
+    }
+  }
+`;
+
+interface IProps {
+  setDateRange: Dispatch<SetStateAction<string[] | null>>;
+}
+
+function DateRange({ setDateRange }: IProps) {
+  const today = new Date();
+  const [checkDeadline, setCheckDeadline] = useState<boolean>(false);
+  const [startDate, setStartDate] = useState<string>(
+    [today.getFullYear(), today.getMonth() + 1, today.getDate()].join('-'),
+  );
+  const [endDate, setEndDate] = useState<string>(startDate);
+
+  const changeStartDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.currentTarget.value > endDate) {
+      setEndDate(e.currentTarget.value);
+    }
+    setStartDate(e.currentTarget.value);
+    setDateRange((prev) => {
+      if (prev === null) {
+        return [startDate, ''];
+      }
+      return [startDate, prev[1]];
+    });
+  };
+
+  const changeEndDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.currentTarget.value < startDate) {
+      setStartDate(e.currentTarget.value);
+    }
+    setEndDate(e.currentTarget.value);
+    setDateRange((prev) => {
+      if (prev === null) {
+        return ['', endDate];
+      }
+      return [prev[0], endDate];
+    });
+  };
+
+  return (
+    <DeadlineField>
+      <div className="deadline-label">
+        <input type="checkbox" checked={checkDeadline} onChange={() => setCheckDeadline((prev) => !prev)} />
+        <div className="label-name">기간</div>
+      </div>
+      {checkDeadline && (
+        <>
+          <div className="deadline-prop">
+            <div className="prop-name-container">
+              <StartDate width="1rem" height="1rem" />
+              <div className="prop-name">시작일</div>
+            </div>
+            <input type="date" value={startDate} onChange={changeStartDate} />
+          </div>
+          <div className="deadline-prop">
+            <div className="prop-name-container">
+              <DeadlineDate width="1rem" height="1rem" />
+              <div className="prop-name">종료일</div>
+            </div>
+            <input type="date" value={endDate} onChange={changeEndDate} />
+          </div>
+        </>
+      )}
+    </DeadlineField>
+  );
+}
+
+export default DateRange;

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -1,69 +1,21 @@
 import React, { useState } from 'react';
 
 import { useRecoilValue } from 'recoil';
-import styled from 'styled-components';
 import { IAddTaskModal, ILabel, ISelectOption, ITask } from 'types';
 
 import DateRange from '@components/DateRange';
 import LabelInput from '@components/LabelInput';
-import { ModalButton } from '@components/Modal/CommonModalStyles';
+import {
+  AssigneeField,
+  Fields,
+  InputField,
+  ModalButton,
+  TaskFormContainer,
+  TaskModalWrapper,
+} from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
 import useModal from '@hooks/useModal';
 import { membersState, modalDataState } from '@recoil/atoms';
-
-const Wrapper = styled.div`
-  width: 100%;
-  height: 100%;
-`;
-
-const FormContainer = styled.form`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 1.5rem;
-`;
-
-const InputField = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  label {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    color: #76808e;
-  }
-
-  input {
-    height: 2.5rem;
-    padding: 1rem;
-    background-color: #fafafa;
-    border-radius: 8px;
-    font-size: 0.9rem;
-
-    &:focus {
-      outline: 1px solid #b8b8b84f;
-    }
-  }
-`;
-
-const Fields = styled.div`
-  height: 4.5rem;
-  display: flex;
-  gap: 3rem;
-`;
-
-const AssigneeField = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-
-  .assignee-label {
-    color: #76808e;
-  }
-`;
 
 export default function AddTaskModal() {
   const members = useRecoilValue(membersState);
@@ -91,6 +43,7 @@ export default function AddTaskModal() {
       assigneeId: assignee.id,
       order: modalData.taskOrder,
       dateRange: dateRange || null,
+      description: '',
     };
     // Plan 페이지 tasks 상태에 반영
     modalData.addTaskHandler((prev) => {
@@ -103,8 +56,8 @@ export default function AddTaskModal() {
   };
 
   return (
-    <Wrapper>
-      <FormContainer onSubmit={submitAddTask}>
+    <TaskModalWrapper>
+      <TaskFormContainer onSubmit={submitAddTask}>
         <InputField>
           <label htmlFor="task-name">
             할 일
@@ -129,7 +82,7 @@ export default function AddTaskModal() {
           <LabelInput alreadySelected={[]} selectedLabelsHandler={setSelectedLabels} />
         </InputField>
         <ModalButton type="submit">추가하기</ModalButton>
-      </FormContainer>
-    </Wrapper>
+      </TaskFormContainer>
+    </TaskModalWrapper>
   );
 }

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -4,8 +4,7 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { IAddTaskModal, ILabel, ISelectOption, ITask } from 'types';
 
-import { ReactComponent as DeadlineDate } from '@assets/images/deadlineCheck.svg';
-import { ReactComponent as StartDate } from '@assets/images/startDate.svg';
+import DateRange from '@components/DateRange';
 import LabelInput from '@components/LabelInput';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
@@ -66,52 +65,11 @@ const AssigneeField = styled.div`
   }
 `;
 
-const DeadlineField = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-
-  .deadline-label {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-
-    .label-name {
-      color: #76808e;
-    }
-  }
-
-  .deadline-prop {
-    padding-left: 0.5rem;
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    justify-content: center;
-
-    .prop-name-container {
-      display: flex;
-      gap: 0.5rem;
-      align-items: center;
-      justify-content: center;
-
-      .prop-name {
-        font-size: 0.8rem;
-      }
-    }
-  }
-`;
-
 export default function AddTaskModal() {
-  const today = new Date();
-
   const members = useRecoilValue(membersState);
   const [taskName, setTaskName] = useState<string>('');
   const [assignee, setAssignee] = useState<ISelectOption>({ id: -1, name: '' });
-  const [checkDeadline, setCheckDeadline] = useState<boolean>(false);
-  const [startDate, setStartDate] = useState<string>(
-    [today.getFullYear(), today.getMonth() + 1, today.getDate()].join('-'),
-  );
-  const [endDate, setEndDate] = useState<string>(startDate);
+  const [dateRange, setDateRange] = useState<string[] | null>(null);
   const [selectedLabels, setSelectedLabels] = useState<ILabel[]>([]);
   const modalData = useRecoilValue(modalDataState) as IAddTaskModal;
   const { closeModal } = useModal();
@@ -119,20 +77,6 @@ export default function AddTaskModal() {
   const options = members.map((member) => {
     return { id: member.id, name: member.name };
   });
-
-  const changeStartDate = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.currentTarget.value > endDate) {
-      setEndDate(e.currentTarget.value);
-    }
-    setStartDate(e.currentTarget.value);
-  };
-
-  const changeEndDate = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.currentTarget.value < startDate) {
-      setStartDate(e.currentTarget.value);
-    }
-    setEndDate(e.currentTarget.value);
-  };
 
   const submitAddTask = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -146,7 +90,7 @@ export default function AddTaskModal() {
       assignee: assignee.name,
       assigneeId: assignee.id,
       order: modalData.taskOrder,
-      dateRange: checkDeadline ? [startDate, endDate] : null,
+      dateRange: dateRange || null,
     };
     // Plan 페이지 tasks 상태에 반영
     modalData.addTaskHandler((prev) => {
@@ -179,30 +123,7 @@ export default function AddTaskModal() {
             <div className="assignee-label">담당자</div>
             <SelectBox options={options} setValue={setAssignee} />
           </AssigneeField>
-          <DeadlineField>
-            <div className="deadline-label">
-              <input type="checkbox" checked={checkDeadline} onChange={() => setCheckDeadline((prev) => !prev)} />
-              <div className="label-name">기간</div>
-            </div>
-            {checkDeadline && (
-              <>
-                <div className="deadline-prop">
-                  <div className="prop-name-container">
-                    <StartDate width="1rem" height="1rem" />
-                    <div className="prop-name">시작일</div>
-                  </div>
-                  <input type="date" value={startDate} onChange={changeStartDate} />
-                </div>
-                <div className="deadline-prop">
-                  <div className="prop-name-container">
-                    <DeadlineDate width="1rem" height="1rem" />
-                    <div className="prop-name">종료일</div>
-                  </div>
-                  <input type="date" value={endDate} onChange={changeEndDate} />
-                </div>
-              </>
-            )}
-          </DeadlineField>
+          <DateRange setDateRange={setDateRange} />
         </Fields>
         <InputField>
           <LabelInput alreadySelected={[]} selectedLabelsHandler={setSelectedLabels} />

--- a/src/components/Modal/CommonModalStyles.ts
+++ b/src/components/Modal/CommonModalStyles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const ModalDescription = styled.p`
+export const ModalInformation = styled.p`
   font-size: 1.2rem;
   text-align: center;
 `;

--- a/src/components/Modal/CommonModalStyles.ts
+++ b/src/components/Modal/CommonModalStyles.ts
@@ -19,3 +19,57 @@ export const ModalButton = styled.button`
   color: white;
   line-height: 10%;
 `;
+
+export const TaskModalWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+export const TaskFormContainer = styled.form`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1.5rem;
+`;
+
+export const InputField = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: #76808e;
+  }
+
+  input {
+    height: 2.5rem;
+    padding: 1rem;
+    background-color: #fafafa;
+    border-radius: 8px;
+    font-size: 0.9rem;
+
+    &:focus {
+      outline: 1px solid #b8b8b84f;
+    }
+  }
+`;
+
+export const Fields = styled.div`
+  height: 4.5rem;
+  display: flex;
+  gap: 3rem;
+`;
+
+export const AssigneeField = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .assignee-label {
+    color: #76808e;
+  }
+`;

--- a/src/components/Modal/EditTask.tsx
+++ b/src/components/Modal/EditTask.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+import { IEditTaskModal, ILabel, ISelectOption, ITask } from 'types';
+
+import DateRange from '@components/DateRange';
+import LabelInput from '@components/LabelInput';
+import {
+  AssigneeField,
+  Fields,
+  InputField,
+  ModalButton,
+  TaskFormContainer,
+  TaskModalWrapper,
+} from '@components/Modal/CommonModalStyles';
+import SelectBox from '@components/SelectBox';
+import useModal from '@hooks/useModal';
+import { membersState, modalDataState } from '@recoil/atoms';
+import { filteredLabelsSelector, memberSelector } from '@recoil/selectors';
+
+const DescriptionField = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: #76808e;
+  }
+
+  textarea {
+    height: 15rem;
+    padding: 1rem;
+    background-color: #fafafa;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    resize: none;
+    overflow-y: scroll;
+
+    &:focus {
+      outline: 1px solid #b8b8b84f;
+    }
+  }
+`;
+
+const ButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: end;
+`;
+
+function EditTaskModal() {
+  const { task, taskOrder, requestAPI } = useRecoilValue(modalDataState) as IEditTaskModal;
+  const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
+  const members = useRecoilValue(membersState);
+  const filteredMember = task.assigneeId ? useRecoilValue(memberSelector(task.assigneeId)) : null;
+
+  const [taskName, setTaskName] = useState<string>(task.title);
+  const [assignee, setAssignee] = useState<ISelectOption>(
+    filteredMember ? { id: task.assigneeId, name: filteredMember.name } : { id: -1, name: '' },
+  );
+  const [dateRange, setDateRange] = useState<string[] | null>(null);
+  const [selectedLabels, setSelectedLabels] = useState<ILabel[]>(filteredLabels);
+  const [taskDescription, setTaskDescription] = useState<string>(task.description);
+  const { closeModal } = useModal();
+
+  const options = members.map((member) => {
+    return { id: member.id, name: member.name };
+  });
+
+  const submitEditTask = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const editedTask: ITask = {
+      // TODO: 백엔드로 할 일 수정 요청
+      id: task.id,
+      title: taskName,
+      tabId: task.tabId,
+      labels: selectedLabels.map((label) => label.id),
+      assignee: assignee.name,
+      assigneeId: assignee.id,
+      order: taskOrder,
+      dateRange: dateRange || null,
+      description: taskDescription,
+    };
+
+    requestAPI(editedTask);
+
+    // TODO: 수정된 할 일을 Plan 페이지의 상태에 저장해야 함
+    closeModal();
+  };
+
+  return (
+    <TaskModalWrapper>
+      <TaskFormContainer onSubmit={submitEditTask}>
+        <InputField>
+          <label htmlFor="task-name">
+            할 일
+            <input
+              type="text"
+              id="task-name"
+              name="task-name"
+              value={taskName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTaskName(e.target.value)}
+              placeholder="할 일이 무엇인지 적어주세요."
+            />
+          </label>
+        </InputField>
+        <Fields>
+          <AssigneeField>
+            <div className="assignee-label">담당자</div>
+            <SelectBox options={options} value={assignee} setValue={setAssignee} />
+          </AssigneeField>
+          <DateRange setDateRange={setDateRange} />
+        </Fields>
+        <InputField>
+          <LabelInput alreadySelected={selectedLabels} selectedLabelsHandler={setSelectedLabels} />
+        </InputField>
+        <DescriptionField>
+          <label htmlFor="task-description">
+            설명
+            <textarea
+              id="task-description"
+              name="task-description"
+              value={taskDescription}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setTaskDescription(e.target.value)}
+              placeholder="할 일에 대해 자유롭게 기록해주세요."
+            />
+          </label>
+        </DescriptionField>
+        <ButtonContainer>
+          <ModalButton type="submit">저장하기</ModalButton>
+        </ButtonContainer>
+      </TaskFormContainer>
+    </TaskModalWrapper>
+  );
+}
+
+export default EditTaskModal;

--- a/src/components/Modal/ExitPlan.tsx
+++ b/src/components/Modal/ExitPlan.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { IExitPlanModal, ISelectOption } from 'types';
 
-import { ModalButton, ModalButtonContainer, ModalDescription } from '@components/Modal/CommonModalStyles';
+import { ModalButton, ModalButtonContainer, ModalInformation } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
 import useModal from '@hooks/useModal';
 import { membersState, modalDataState } from '@recoil/atoms';
@@ -33,7 +33,7 @@ export default function ExitPlanModal() {
 
   return (
     <>
-      <ModalDescription>{modalData.description}</ModalDescription>
+      <ModalInformation>{modalData.information}</ModalInformation>
       <SelectAdminContainer>
         <SelectAdminText>관리자 지정</SelectAdminText>
         <SelectBox options={options} setValue={setAdmin} />

--- a/src/components/Modal/Normal.tsx
+++ b/src/components/Modal/Normal.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { INormalModal } from 'types';
 
-import { ModalButton, ModalButtonContainer, ModalDescription } from '@components/Modal/CommonModalStyles';
+import { ModalButton, ModalButtonContainer, ModalInformation } from '@components/Modal/CommonModalStyles';
 import useModal from '@hooks/useModal';
 import { modalDataState } from '@recoil/atoms';
 
@@ -19,7 +19,7 @@ export default function NormalModal() {
 
   return (
     <>
-      <ModalDescription>{modalData.description}</ModalDescription>
+      <ModalInformation>{modalData.information}</ModalInformation>
       <ModalButtonContainer>
         <ModalButton type="button" onClick={onClickHandler}>
           예

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -11,6 +11,11 @@ import ModalPortal from '@components/Modal/Portal';
 import useModal from '@hooks/useModal';
 import { modalState } from '@recoil/atoms';
 
+interface IModalSize {
+  width: number;
+  height: number;
+}
+
 const ModalOverlay = styled.div`
   position: absolute;
   top: 0;
@@ -24,10 +29,10 @@ const ModalOverlay = styled.div`
   background: rgba(100, 212, 171, 0.1);
 `;
 
-const ModalWrapper = styled.div<{ type: string }>`
+const ModalWrapper = styled.div<{ size: IModalSize }>`
   padding: 3rem 2.5rem;
-  width: ${(props) => (props.type === 'addTask' ? '56' : '32')}rem;
-  height: ${(props) => (props.type === 'addTask' ? '32' : '18')}rem;
+  width: ${(props) => props.size.width}rem;
+  height: ${(props) => props.size.height}rem;
   background: rgba(255, 255, 255, 1);
   border-radius: 8px;
   box-shadow: 0px 4px 16px 4px rgba(0, 0, 0, 0.2);
@@ -46,6 +51,13 @@ export default function Modal() {
   const { isOpen, type } = useRecoilValue(modalState);
   const { closeModal } = useModal();
 
+  const modalSize: Record<string, IModalSize> = {
+    normal: { width: 32, height: 18 },
+    exitPlan: { width: 32, height: 18 },
+    addTask: { width: 56, height: 32 },
+    editTask: { width: 56, height: 48 },
+  };
+
   useEffect(() => {
     const keyDownEscCloseModal = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -61,7 +73,7 @@ export default function Modal() {
       {isOpen && (
         <ModalPortal>
           <ModalOverlay onClick={closeModal}>
-            <ModalWrapper type={type} onClick={(e) => e.stopPropagation()}>
+            <ModalWrapper size={modalSize[type]} onClick={(e) => e.stopPropagation()}>
               <ModalContainer>
                 {type === 'normal' && <NormalModal />}
                 {type === 'exitPlan' && <ExitPlanModal />}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import AddTaskModal from '@components/Modal/AddTask';
+import EditTaskModal from '@components/Modal/EditTask';
 import ExitPlanModal from '@components/Modal/ExitPlan';
 import NormalModal from '@components/Modal/Normal';
 import ModalPortal from '@components/Modal/Portal';
@@ -78,6 +79,7 @@ export default function Modal() {
                 {type === 'normal' && <NormalModal />}
                 {type === 'exitPlan' && <ExitPlanModal />}
                 {type === 'addTask' && <AddTaskModal />}
+                {type === 'editTask' && <EditTaskModal />}
               </ModalContainer>
             </ModalWrapper>
           </ModalOverlay>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -23,6 +23,7 @@ interface ITabProps {
   onSaveTitle: (title: string) => void;
   onAddTask: Dispatch<SetStateAction<Record<number, ITask[]>>>;
   onRemoveTask: (tabId: number, taskId: number) => void;
+  onEditTask?: (tabId: number, taskId: number, editedTask: ITask) => void;
 }
 
 interface ITabHeaderProps {
@@ -37,6 +38,7 @@ interface ITaskContainerProps {
   tasks?: ITask[];
   onAddTask?: Dispatch<SetStateAction<Record<number, ITask[]>>>;
   onRemoveTask?: (tabId: number, taskId: number) => void;
+  onEditTask?: (tabId: number, taskId: number, editedTask: ITask) => void;
 }
 
 const Wrapper = styled.li`
@@ -165,7 +167,7 @@ function TabHeader({ initialTitle, onDeleteTab, onSaveTitle }: ITabHeaderProps) 
   );
 }
 
-export function TasksContainer({ id, tasks, onAddTask, onRemoveTask }: ITaskContainerProps) {
+export function TasksContainer({ id, tasks, onAddTask, onRemoveTask, onEditTask }: ITaskContainerProps) {
   const { openModal } = useModal();
   const setModalData = useSetRecoilState(modalDataState);
 
@@ -187,7 +189,13 @@ export function TasksContainer({ id, tasks, onAddTask, onRemoveTask }: ITaskCont
             <TaskList {...provided.droppableProps} ref={provided.innerRef}>
               {tasks?.map((task, index) => (
                 // TODO: void 함수를 주는 것 외에 다른 방식을 생각해볼 필요가 있음
-                <TaskItem key={task.id} task={task} index={index} onRemoveTask={onRemoveTask || (() => {})} />
+                <TaskItem
+                  key={task.id}
+                  task={task}
+                  index={index}
+                  onRemoveTask={onRemoveTask || (() => {})}
+                  onEditTask={onEditTask || (() => {})}
+                />
               ))}
               {provided.placeholder}
             </TaskList>
@@ -206,11 +214,21 @@ export function TasksContainer({ id, tasks, onAddTask, onRemoveTask }: ITaskCont
   );
 }
 
-export function Tab({ id, index, title, tasks, onDeleteTab, onSaveTitle, onAddTask, onRemoveTask }: ITabProps) {
+export function Tab({
+  id,
+  index,
+  title,
+  tasks,
+  onDeleteTab,
+  onSaveTitle,
+  onAddTask,
+  onRemoveTask,
+  onEditTask,
+}: ITabProps) {
   return (
     <Wrapper className="dnd-tab" data-index={index} data-id={id}>
       <TabHeader initialTitle={title} onDeleteTab={onDeleteTab} onSaveTitle={onSaveTitle} />
-      <TasksContainer id={id} tasks={tasks} onAddTask={onAddTask} onRemoveTask={onRemoveTask} />
+      <TasksContainer id={id} tasks={tasks} onAddTask={onAddTask} onRemoveTask={onRemoveTask} onEditTask={onEditTask} />
     </Wrapper>
   );
 }

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -14,8 +14,15 @@ import { modalDataState } from '@recoil/atoms';
 import { filteredLabelsSelector, memberSelector } from '@recoil/selectors';
 import { hashStringToColor } from '@utils';
 
-const ItemContainer = styled.div`
+const ItemWrapper = styled.div`
   position: relative;
+  width: 100%;
+
+  &:hover .task-remove-button {
+    display: flex;
+  }
+`;
+const ItemContainer = styled.div`
   padding: 1rem;
   margin-bottom: 1rem;
   width: 99%;
@@ -31,23 +38,19 @@ const ItemContainer = styled.div`
     word-wrap: break-word;
   }
 
-  button {
-    display: none;
-    width: 1rem;
-    height: 1rem;
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    color: #f44336;
-  }
-
   &:hover {
     background-color: #ececec;
   }
+`;
 
-  &:hover button {
-    display: flex;
-  }
+const TaskRemoveButton = styled.button`
+  display: none;
+  width: 1rem;
+  height: 1rem;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  color: #f44336;
 `;
 
 const LabelField = styled.div`
@@ -109,38 +112,40 @@ export default function TaskItem({ task, index, onRemoveTask }: Props) {
   return (
     <Draggable draggableId={task.id.toString()} index={index}>
       {(provided) => (
-        <ItemContainer {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef}>
-          <button type="button" onClick={removeTaskHandler}>
-            <IoClose size={20} />
-          </button>
-          <p id="task-title">{task.title}</p>
-          <LabelField>
-            {filteredLabels.map((label) => (
-              <LabelItem key={label.id} color={hashStringToColor(label.value)}>
-                {label.value}
-              </LabelItem>
-            ))}
-          </LabelField>
-          <InfoField>
-            <DateField>
-              {task.dateRange ? (
-                <>
-                  <PiClockFill size={16} color="#64D4AB" />
-                  <div>
-                    {`${task.dateRange[0]}`}
-                    <br />
-                    {` ~ ${task.dateRange[1]}`}
+        <ItemWrapper>
+          <ItemContainer {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef}>
+            <p id="task-title">{task.title}</p>
+            <LabelField>
+              {filteredLabels.map((label) => (
+                <LabelItem key={label.id} color={hashStringToColor(label.value)}>
+                  {label.value}
+                </LabelItem>
+              ))}
+            </LabelField>
+            <InfoField>
+              <DateField>
+                {task.dateRange ? (
+                  <>
+                    <PiClockFill size={16} color="#64D4AB" />
+                    <div>
+                      {`${task.dateRange[0]}`}
+                      <br />
+                      {` ~ ${task.dateRange[1]}`}
+                    </div>
+                  </>
+                ) : (
+                  <div className="date-infinity">
+                    <IoInfinite size={24} color="#1C2A4B" />
                   </div>
-                </>
-              ) : (
-                <div className="date-infinity">
-                  <IoInfinite size={24} color="#1C2A4B" />
-                </div>
-              )}
-            </DateField>
-            <div>{assignee.name}</div>
-          </InfoField>
-        </ItemContainer>
+                )}
+              </DateField>
+              <div>{assignee.name}</div>
+            </InfoField>
+          </ItemContainer>
+          <TaskRemoveButton className="task-remove-button" type="button" onClick={removeTaskHandler}>
+            <IoClose size={20} />
+          </TaskRemoveButton>
+        </ItemWrapper>
       )}
     </Draggable>
   );

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -105,7 +105,7 @@ export default function TaskItem({ task, index, onRemoveTask }: Props) {
       // TODO: 서버에 태스크 삭제 요청
       onRemoveTask(task.tabId, task.id);
     };
-    setModalData({ description: `"${task.title}"을 삭제할까요?`, requestAPI } as INormalModal);
+    setModalData({ information: `"${task.title}"을 삭제할까요?`, requestAPI } as INormalModal);
     openModal('normal');
   };
 

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -7,7 +7,7 @@ import { IoClose, IoInfinite } from 'react-icons/io5';
 import { PiClockFill } from 'react-icons/pi';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
-import { INormalModal, ITask } from 'types';
+import { IEditTaskModal, INormalModal, ITask } from 'types';
 
 import useModal from '@hooks/useModal';
 import { modalDataState } from '@recoil/atoms';
@@ -92,9 +92,10 @@ interface Props {
   task: ITask;
   index: number;
   onRemoveTask: (tabId: number, taskId: number) => void;
+  onEditTask: (tabId: number, taskId: number, editedTask: ITask) => void;
 }
 
-export default function TaskItem({ task, index, onRemoveTask }: Props) {
+export default function TaskItem({ task, index, onRemoveTask, onEditTask }: Props) {
   const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
   const assignee = useRecoilValue(memberSelector(task.assigneeId!));
   const setModalData = useSetRecoilState(modalDataState);
@@ -109,11 +110,25 @@ export default function TaskItem({ task, index, onRemoveTask }: Props) {
     openModal('normal');
   };
 
+  const editTaskHandler = () => {
+    const requestAPI = (editedTask: ITask) => {
+      onEditTask(task.tabId, task.id, editedTask);
+      // TODO: 서버에 태스크 업데이트 요청
+    };
+    setModalData({ task, taskOrder: index, requestAPI } as IEditTaskModal);
+    openModal('editTask');
+  };
+
   return (
     <Draggable draggableId={task.id.toString()} index={index}>
       {(provided) => (
         <ItemWrapper>
-          <ItemContainer {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef}>
+          <ItemContainer
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            ref={provided.innerRef}
+            onClick={editTaskHandler}
+          >
             <p id="task-title">{task.title}</p>
             <LabelField>
               {filteredLabels.map((label) => (

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -309,11 +309,9 @@ function Plan() {
 
   const handleDeleteTask = (tabId: number, taskId: number) => {
     if (tasks) {
-      let idx = 0;
-      while (tasks[tabId][idx] && tasks[tabId][idx].id !== taskId) idx += 1;
       setTasks((prev) => {
         const newTasks = { ...prev };
-        newTasks[tabId].splice(idx, 1);
+        newTasks[tabId] = newTasks[tabId].filter((task) => task.id !== taskId);
         return newTasks;
       });
     }

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -319,6 +319,19 @@ function Plan() {
     }
   };
 
+  const handleEditTask = (tabId: number, taskId: number, editedTask: ITask) => {
+    if (tasks) {
+      let idx = 0;
+      while (tasks[tabId][idx] && tasks[tabId][idx].id !== taskId) idx += 1;
+      setTasks((prev) => {
+        const newTasks = { ...prev };
+        newTasks[tabId].splice(idx, 1);
+        newTasks[tabId].splice(idx, 0, editedTask);
+        return newTasks;
+      });
+    }
+  };
+
   const handleDeleteTab = (tabId: number) => {
     if (plan) {
       const updatedTabOrder = plan.tabOrder.filter((item) => item !== tabId);
@@ -448,6 +461,7 @@ function Plan() {
                     onSaveTitle={handleSaveTabTitle}
                     onAddTask={setTasks}
                     onRemoveTask={handleDeleteTask}
+                    onEditTask={handleEditTask}
                   />
                 );
               })}

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -230,7 +230,7 @@ function Setting() {
     const requestAPI = () => {
       // TODO: 서버에 플랜 삭제 요청
     };
-    setModalData({ description: `플랜을 정말 삭제하시겠어요?`, requestAPI } as INormalModal);
+    setModalData({ information: `플랜을 정말 삭제하시겠어요?`, requestAPI } as INormalModal);
     openModal('normal');
   };
 
@@ -238,7 +238,7 @@ function Setting() {
     const requestAPI = () => {
       // TODO: 서버에 플랜 수정 요청
     };
-    setModalData({ description: `변경사항을 저장하시겠어요?`, requestAPI } as INormalModal);
+    setModalData({ information: `변경사항을 저장하시겠어요?`, requestAPI } as INormalModal);
     openModal('normal');
   };
 

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -33,6 +33,11 @@ export default createGlobalStyle`
     font-size: inherit;
   }
 
+  textarea {
+    border: none;
+    font-size: inherit;
+  }
+
   button {
     background: none;
     border: none;
@@ -41,7 +46,7 @@ export default createGlobalStyle`
     font-size: inherit;
     &:focus{
       outline: none;
-    } 
+    }
   }
 
   ul,li{

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,7 +49,7 @@ export interface IModalInfo {
 }
 
 export interface INormalModal {
-  description: string;
+  information: string;
   requestAPI: () => void;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export interface ITask {
   assigneeId: number | undefined;
   order: number;
   dateRange: null | string[];
+  description: string;
 }
 
 export interface IMember {
@@ -61,6 +62,12 @@ export interface IAddTaskModal {
   addTaskHandler: Dispatch<SetStateAction<Record<number, ITask[]>>>;
 }
 
+export interface IEditTaskModal {
+  task: ITask;
+  taskOrder: number;
+  requestAPI: (editedTask: ITask) => void;
+}
+
 export type TModalType = 'none' | 'normal' | 'exitPlan' | 'addTask' | 'editTask';
 
-export type TModalData = null | INormalModal | IExitPlanModal | IAddTaskModal;
+export type TModalData = null | INormalModal | IExitPlanModal | IAddTaskModal | IEditTaskModal;


### PR DESCRIPTION
## 📌 Description
- 모달 크기를 직접 정의하고 사용할 수 있도록 변경했습니다.
- 더미데이터에서 description이 빠져있어서 추가했습니다.
- 할 일 수정 모달을 구현했습니다.
- 공통 컴포넌트와 공통 스타일들을 분리했습니다.
- 저번 PR에서 현님이 말씀하신대로 할 일을 삭제할 때 `filter`를 이용하여 삭제하도록 변경했습니다.

## ⚠️ 주의사항
- 자려다 갑자기 생각나서 구현했네요 ㅎ;
- 할 일 수정 모달에서 설명에 대한 입력 창이 꽤 큰데 `textarea`로 받는 것이 맞겠죠..?

close #73 