### PR TITLE
[#75]팀원 초대시 이메일 유효성 검사 추가

### DIFF
--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -94,10 +94,21 @@ function CreatePlan() {
   };
 
   const addMember = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const value = e.currentTarget.value.trim();
-    if (e.key !== 'Enter' || !value) return;
-    setMemberEmailList((prev) => [...prev, value]);
-    e.currentTarget.value = '';
+    if (e.key === 'Enter') {
+      const value = e.currentTarget.value.trim();
+
+      if (!value) return;
+
+      const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+
+      if (!emailPattern.test(value)) {
+        // eslint-disable-next-line no-alert
+        alert('유효한 이메일 주소를 입력하세요.');
+        return;
+      }
+      setMemberEmailList((prev) => [...prev, value]);
+      e.currentTarget.value = '';
+    }
   };
 
   const deleteMember = (deletedEmail: string) => {

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -202,10 +202,22 @@ function Setting() {
   };
 
   const handleAddMember = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const value = e.currentTarget.value.trim();
-    if (e.key !== 'Enter' || !value) return;
-    setNewMemberEmailList((prev) => [...prev, value]);
-    e.currentTarget.value = '';
+    if (e.key === 'Enter') {
+      const value = e.currentTarget.value.trim();
+
+      if (!value) return;
+
+      const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+
+      if (!emailPattern.test(value)) {
+        // eslint-disable-next-line no-alert
+        alert('유효한 이메일 주소를 입력하세요.');
+        return;
+      }
+
+      setNewMemberEmailList((prev) => [...prev, value]);
+      e.currentTarget.value = '';
+    }
   };
 
   const handleDeleteNewMember = (deletedEmail: string) => {


### PR DESCRIPTION
📌 Description
- addMember 함수에 이메일 유효성 검사를 추가했습니다.
- gmail이외의 도메인에 대해서도 가능하게 만들었습니다.

⚠️ 주의사항
- 플랜 페이지에서 탭 삭제하는 모달이 필요해요!
- 유효성 검사를 통과하지 못하면 alert되게 해놨는데 이것도 모달창이 필요할 것 같습니다.

close #75