### PR TITLE
[#79] 구글 OAuth 로직 리팩토링

### DIFF
--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -57,10 +57,19 @@ const LoginPolicy = styled.div`
 `;
 
 export default function SignIn() {
-  const requestGoogleOAuth = async () => {
-    const { data } = await axios.get('/oauth/google/authorized-uri');
-    const oauthUrl = data.authorizedUri;
-    window.location.assign(oauthUrl);
+  const handleOAuthRedirect = async () => {
+    try {
+      const response = await axios.get('/oauth/google/authorized-uri');
+      const oauthUrl = response.data.authorizedUri;
+
+      if (oauthUrl) {
+        window.location.assign(oauthUrl);
+      } else {
+        throw Error('서버로부터 oauthUrl을 받아오지 못했습니다.');
+      }
+    } catch (error) {
+      // 에러 처리
+    }
   };
 
   return (
@@ -73,7 +82,7 @@ export default function SignIn() {
             혼자 혹은 동료와 새로운 <HighlightSpan>플랜</HighlightSpan>을 생성해보세요.
           </span>
         </Descripton>
-        <GoogleOAuthButton type="button" onClick={requestGoogleOAuth}>
+        <GoogleOAuthButton type="button" onClick={handleOAuthRedirect}>
           <ButtonContainer>
             <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="32" height="32" viewBox="0 0 48 48">
               <path

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef } from 'react';
 
+import axios from 'axios';
+import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import defaultProfileImg from '@assets/images/defaultProfileImg.svg';
@@ -77,8 +79,13 @@ const SubmitButton = styled.button`
 `;
 
 export default function SignUp() {
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const location = useLocation();
+  const userData = location.state;
+  const [name, setName] = useState<string>('');
+  const [imagePreview, setImagePreview] = useState<string | null>(userData.profileUrl);
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // console.log(userData);
 
   const uploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
@@ -94,9 +101,26 @@ export default function SignUp() {
     }
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const formData = new FormData();
+
+    if (inputRef.current && inputRef.current.files) {
+      formData.append('profileImage', inputRef.current.files[0]);
+    }
+
+    formData.append('name', name);
     // TODO: 서버에 회원가입 POST 요청
+    try {
+      const response = await axios.post('/api/auth/register', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data', // 확인필요
+        },
+      });
+      return response;
+    } catch {
+      throw Error('회원가입에 실패했습니다.');
+    }
   };
 
   return (
@@ -111,8 +135,8 @@ export default function SignUp() {
           </AddImageButton>
         </ProfileImageContainer>
         <InputContainer>
-          <Input type="text" placeholder="이름" readOnly />
-          <Input type="text" placeholder="이메일" readOnly />
+          <Input type="text" placeholder="이름을 알려주세요" value={name} onChange={(e) => setName(e.target.value)} />
+          <Input type="email" placeholder="이메일" value={userData.email} readOnly />
         </InputContainer>
         <SubmitButton type="submit">시작하기</SubmitButton>
       </Form>


### PR DESCRIPTION
📌 Description
- GoogleOauthCallback의 로직을 예외처리가 더 쉽도록 리팩토링했습니다.
- 로그인 요청 후 받아온 데이터를 회원가입 페이지로 넘겨주었습니다.
- 회원가입 요청시 profileUrl을 담을 formData를 만들었습니다.

⚠️ 주의사항
- 이미지 업로드 요청할 때 formData에 넣는 거 말고 다른 방법이 있는지 궁금합니다. 
- 헤더에 유저 프로필 이미지를 보여주려면 로그인 후 받은 imgUrl을 전역 상태로 관리해야 할 것 같습니다.

close #79