### PR TITLE
[#82] 플랜 생성 페이지 연결

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 
 import { ImCompass2 } from 'react-icons/im';
-import { LuCalendarPlus } from 'react-icons/lu';
-import { MdHome, MdCalendarMonth } from 'react-icons/md';
+import { LuCalendarPlus, LuCalendarDays } from 'react-icons/lu';
+import { MdHome } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 
@@ -68,7 +68,7 @@ const NavLink = styled(Link)<{ selected: boolean }>`
 const navMenu = [
   { id: 1, value: 'home', icon: MdHome, link: '/' },
   { id: 2, value: 'createPlan', icon: LuCalendarPlus, link: '/create-plan' },
-  { id: 3, value: 'plan', icon: MdCalendarMonth, link: '/plan' },
+  { id: 3, value: 'plan', icon: LuCalendarDays, link: '/plan' },
   { id: 4, value: 'explore', icon: ImCompass2, link: '/#' },
 ];
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import { ImCompass2 } from 'react-icons/im';
+import { LuCalendarPlus } from 'react-icons/lu';
 import { MdHome, MdCalendarMonth } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -66,8 +67,9 @@ const NavLink = styled(Link)<{ selected: boolean }>`
 // TODO: navMenu link 수정
 const navMenu = [
   { id: 1, value: 'home', icon: MdHome, link: '/' },
-  { id: 2, value: 'plan', icon: MdCalendarMonth, link: '/plan' },
-  { id: 3, value: 'explore', icon: ImCompass2, link: '/#' },
+  { id: 2, value: 'createPlan', icon: LuCalendarPlus, link: '/create-plan' },
+  { id: 3, value: 'plan', icon: MdCalendarMonth, link: '/plan' },
+  { id: 4, value: 'explore', icon: ImCompass2, link: '/#' },
 ];
 
 const dropdownOptions = [


### PR DESCRIPTION
## 📌 Description
- 헤더의 아이콘을 통해 플랜 생성 페이지로 이동할 수 있도록 연결하였습니다.
- 플랜 페이지의 아이콘과 일관성이 조금 깨져보여 아이콘을 수정하였습니다.

## ⚠️ 주의사항
- 헤더 코드를 깔끔하게 짜주셔서 수정이 굉장히 편했네요 ㅎㅎ

close #82 