### PR TITLE
[#100] 플랜 설정 api 연동 및 플랜 삭제, 생성 시 currentPageId 버그 수정

### DIFF
--- a/src/components/ManageTeam/index.tsx
+++ b/src/components/ManageTeam/index.tsx
@@ -46,7 +46,7 @@ function ManageTeam({
               <Item key={item.id}>
                 <div className="memberInfo">
                   <span className="name">{item.name}</span>
-                  <span>{item.email}</span>
+                  <span>{item.mail}</span>
                 </div>
                 <div className="delete">
                   {deletedExistMemberIdList?.includes(item.id) && <span className="pending">삭제 예정</span>}

--- a/src/components/MemberFilter/index.tsx
+++ b/src/components/MemberFilter/index.tsx
@@ -21,7 +21,7 @@ export default function MemberFilter({ selectedMember, onClick }: IMmeberFilterP
       {memberList.map((item) => (
         <MemberItem key={item.id} onClick={() => onClick(item.id)}>
           <MemberImg
-            src={item.imgUrl}
+            src={item.imgSrc}
             alt="profile-img"
             className={`${selectedMember.includes(item.id) && 'selected'}`}
           />

--- a/src/pages/CreatePlan/index.tsx
+++ b/src/pages/CreatePlan/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import {
   Wrapper,
@@ -17,6 +18,7 @@ import boardIllust from '@assets/images/boardIllust.svg';
 import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
 import ToggleSwitch from '@components/ToggleSwitch';
+import { currentPlanIdState } from '@recoil/atoms';
 
 type PlanInfo = {
   title: string;
@@ -31,6 +33,7 @@ function CreatePlan() {
   const [invitedEmails, setInvitedEmails] = useState<string[]>([]);
   const [isPublic, setIsPublic] = useState<boolean>(false);
   const navigate = useNavigate();
+  const setCurrentPlanId = useSetRecoilState(currentPlanIdState);
 
   const changePlanInfo = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -78,6 +81,13 @@ function CreatePlan() {
     try {
       const { status, data } = await axios.post('/api/plans', requestData);
       if (status === 201) {
+        // setCurrentPlanId를 변경하지 않고 plan/data.id로 가는경우
+        // 경로에 있는 data.id를 사용해서 데이터를 불러오지 않고
+        // recoil에 이미 저장되어 있는 id의 플랜 정보를 불러온다.
+        // 즉 플랜이 없다가 만들어진 경우
+        // 이전 recoil에 currentPlanId가 없기 때문에
+        // plan 페이지로 넘어갔을 떄 데이터를 받아오지 않는다.
+        setCurrentPlanId(data.id);
         navigate(`/plan/${data.id}`);
       } else {
         throw new Error();

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -36,7 +36,7 @@ interface IPlan {
   id: number;
   title: string;
   description: string;
-  isPublic: boolean;
+  public: boolean;
   members: IMember[];
   tabOrder: number[];
   tabs: ITab[];
@@ -339,6 +339,8 @@ function Plan() {
     });
   };
 
+  // console.log(plan);
+
   return (
     <Wrapper>
       <SideContainer>
@@ -368,7 +370,20 @@ function Plan() {
             <div className="icon">
               <IoIosStarOutline size={25} />
             </div>
-            <div className="icon" onClick={() => navigate('/setting')}>
+            <div
+              className="icon"
+              onClick={() =>
+                navigate('/setting', {
+                  state: {
+                    id: plan.id,
+                    title: plan.title,
+                    intro: plan.description,
+                    isPublic: plan.public,
+                    members: plan.members,
+                  },
+                })
+              }
+            >
               <CiSettings size={28} />
             </div>
           </UtilContainer>

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -140,7 +140,8 @@ function Plan() {
     };
 
     fetchData();
-  }, [planId]);
+    // 의존성에 planTitles를 넣어줘야 플랜이 없다가 생성했을때 플랜페이지로 돌아와서 plan정보를 받아옴
+  }, [planId, planTitles]);
 
   useEffect(() => {
     if (originalPlan) {
@@ -374,7 +375,7 @@ function Plan() {
       </SideContainer>
       <MainContainer>
         {/* TODO: planTitles가 빈 배열인 경우 비어있는 UI 만들어야함 */}
-        {planTitles.length === 0 && <div>loading</div>}
+        {planTitles.length === 0 && <div>플랜이 없습니다.</div>}
         <TopContainer>
           <MemberFilter selectedMember={selectedMembers} onClick={handleChangeMember} />
           <UtilContainer>

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -7,7 +7,7 @@ import { DragDropContext, OnDragEndResponder } from 'react-beautiful-dnd';
 import { CiSettings } from 'react-icons/ci';
 import { IoIosStarOutline } from 'react-icons/io';
 import { SlPlus } from 'react-icons/sl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { ITask, ITab, IMember, ILabel } from 'types';
 
@@ -57,6 +57,7 @@ interface IDragDropResult {
 }
 
 function Plan() {
+  const { planId } = useParams();
   const [currentPlanId, setCurrentPlanId] = useRecoilState(currentPlanIdState);
   const [originalPlan, setOriginalPlan] = useState<IPlan | null>(null);
   const [plan, setPlan] = useState<IPlan | null>(null);
@@ -105,7 +106,7 @@ function Plan() {
       try {
         const { data } = await axios.get('/api/plans/all');
         setPlanTitles(data);
-        if (currentPlanId === -1) setCurrentPlanId(data[0].id);
+        if (currentPlanId === -1 && data.length > 0) setCurrentPlanId(data[0].id);
       } catch (error) {
         // eslint-disable-next-line
         console.log(error);
@@ -115,10 +116,20 @@ function Plan() {
   }, []);
 
   useEffect(() => {
+    // 플랜 4가 삭제되어도 recoil은 4를 갖고 있어서 fetch할때 에러가 난다.
+    // setting에서 플랜 삭제시 planTitles에서 4를 없앤다.
+    // setting에서 플랜 삭제시 바로 currentPlanId를 planTitles의 0로 바꾸고 싶었지만
+    // 0번째를 삭제한 경우 planTitle이 변화가 없기 떄문에 currentPlanId가 삭제된 id와 동일해서 못 받아온다.
+    if (planId === undefined && planTitles.length > 0) {
+      setCurrentPlanId(planTitles[0].id);
+    }
+
     const fetchData = async () => {
-      if (currentPlanId === -1) return;
+      // planTitles가 빈 배열인 경우 데이터를 가져올 데이터가 없다.
+      if (currentPlanId === -1 || planTitles.length === 0) return;
+
       try {
-        const data = await getPlanInfo(currentPlanId);
+        const data = await getPlanInfo(planId === undefined ? planTitles[0].id : currentPlanId);
         setMembers(data.members);
         setLabels(data.labels);
         setOriginalPlan(data); // 원래의 플랜 데이터 저장
@@ -129,7 +140,7 @@ function Plan() {
     };
 
     fetchData();
-  }, [currentPlanId]);
+  }, [planId]);
 
   useEffect(() => {
     if (originalPlan) {
@@ -339,8 +350,6 @@ function Plan() {
     });
   };
 
-  // console.log(plan);
-
   return (
     <Wrapper>
       <SideContainer>
@@ -364,6 +373,8 @@ function Plan() {
         <LabelFilter selectedLabels={selectedLabels} onChange={handleChangeLabel} />
       </SideContainer>
       <MainContainer>
+        {/* TODO: planTitles가 빈 배열인 경우 비어있는 UI 만들어야함 */}
+        {planTitles.length === 0 && <div>loading</div>}
         <TopContainer>
           <MemberFilter selectedMember={selectedMembers} onClick={handleChangeMember} />
           <UtilContainer>

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 
 import axios from 'axios';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useSetRecoilState, useRecoilState } from 'recoil';
 import { IMember, INormalModal, ISelectOption } from 'types';
 
@@ -35,6 +35,8 @@ function Setting() {
   const setModalData = useSetRecoilState(modalDataState);
   const { openModal } = useModal();
   const [planTitles, setPlanTitles] = useRecoilState(planTitlesState);
+
+  const navigate = useNavigate();
 
   const options = state.members.map((member: IMember) => {
     return { id: member.id, name: member.name };
@@ -92,6 +94,7 @@ function Setting() {
           window.alert(`플랜이 삭제되었습니다.`);
           setPlanTitles(planTitles.filter((item) => item.id !== state.id));
           // TODO: 플랜 페이지로 이동
+          navigate('/plan');
         }
       } catch (error) {
         console.error('Error deleting plan:', error);

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 
+import axios from 'axios';
+import { useLocation } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
-import { INormalModal, ISelectOption } from 'types';
+import { IMember, INormalModal, ISelectOption } from 'types';
 
 import { Wrapper, Title, ManageTeamContainer, ImportantSetting, SettingItem, ButtonContainer, Button } from './styles';
 
@@ -15,117 +17,24 @@ import { modalDataState } from '@recoil/atoms';
 
 interface IPlanInfo {
   title: string;
-  description: string;
+  intro: string;
 }
 
-const planData = {
-  title: 'planting',
-  description: '안녕하세요 저희는 일정 공유 관리 서비스를 개발하고 있는 플랜팅입니다.',
-  isPublic: true,
-  members: [
-    {
-      id: 1,
-      name: '신우성',
-      imgUrl:
-        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-      isAdmin: true,
-      email: 'cys@gmail.com',
-    },
-    {
-      id: 2,
-      name: '김태훈',
-      imgUrl:
-        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-      isAdmin: false,
-      email: 'kth@gmail.com',
-    },
-    {
-      id: 3,
-      name: '허준영',
-      imgUrl:
-        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-      isAdmin: false,
-      email: 'hjy@gmail.com',
-    },
-    {
-      id: 4,
-      name: '한현',
-      imgUrl:
-        'https://images.unsplash.com/photo-1466112928291-0903b80a9466?auto=format&fit=crop&q=80&w=873&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-      isAdmin: false,
-      email: 'hh@gmail.com',
-    },
-  ],
-  tabOrder: [2, 1, 3],
-  tabs: [
-    {
-      id: 3,
-      title: 'Done',
-    },
-    {
-      id: 1,
-      title: 'To do',
-    },
-    {
-      id: 2,
-      title: 'In Progress',
-    },
-  ],
-  labels: [
-    { id: 1, value: '개발도서' },
-    { id: 2, value: '코테' },
-    { id: 3, value: '이력서' },
-  ],
-  tasks: [
-    {
-      id: 1,
-      title: 'NC SOFT 서류 제출',
-      tabId: 3,
-      labels: [3],
-      assigneeId: 3,
-      order: 0,
-    },
-    {
-      id: 2,
-      title: '이펙티브 완독',
-      tabId: 1,
-      labels: [1],
-      assigneeId: 3,
-      order: 0,
-    },
-    {
-      id: 3,
-      title: '타입스크립트 Chap1',
-      tabId: 2,
-      labels: [1],
-      assigneeId: 4,
-      order: 0,
-    },
-    {
-      id: 4,
-      title: '백준 삼성 기출',
-      tabId: 2,
-      labels: [2],
-      assigneeId: 1,
-      order: 1,
-    },
-  ],
-};
-
 function Setting() {
+  const { state } = useLocation();
   const [planInfo, setPlanInfo] = useState<IPlanInfo>({
-    title: planData.title,
-    description: planData.description,
+    title: state.title,
+    intro: state.intro,
   });
   const [newMemberEmailList, setNewMemberEmailList] = useState<string[]>([]);
-  const initialAdmin = planData.members.find((item) => item.isAdmin === true);
   const [deletedExistMemberIdList, setDeletedExistMemberIdList] = useState<number[]>([]);
+  const initialAdmin = state.members.find((item: IMember) => item.admin === true);
   const [admin, setAdmin] = useState<ISelectOption>({ id: initialAdmin?.id, name: initialAdmin?.name });
-  const [isPublic, setIsPublic] = useState<boolean>(planData.isPublic);
+  const [isPublic, setIsPublic] = useState<boolean>(state.isPublic);
   const setModalData = useSetRecoilState(modalDataState);
   const { openModal } = useModal();
 
-  const options = planData.members.map((member) => {
+  const options = state.members.map((member: IMember) => {
     return { id: member.id, name: member.name };
   });
 
@@ -172,17 +81,43 @@ function Setting() {
   };
 
   const handleDeletePlan = () => {
-    const requestAPI = () => {
-      // TODO: 서버에 플랜 삭제 요청
+    const requestAPI = async () => {
+      try {
+        const response = await axios.delete(`/api/plans/${state.id}`);
+
+        if (response.status === 204) {
+          // eslint-disable-next-line no-alert
+          window.alert(`플랜이 삭제되었습니다.`);
+          // TODO: 플랜 페이지로 이동
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Error deleting plan:', error);
+        throw error;
+      }
     };
     setModalData({ information: `플랜을 정말 삭제하시겠어요?`, requestAPI } as INormalModal);
     openModal('normal');
   };
 
   const handleSavePlan = () => {
-    const requestAPI = () => {
-      // TODO: 서버에 플랜 수정 요청
+    const requestBody = {
+      ...planInfo,
+      isPublic,
+      ownerId: admin.id,
     };
+    const requestAPI = async () => {
+      // TODO: 서버에 플랜 수정 요청
+      // TODO: 초대 및 강퇴
+      // console.log(deletedExistMemberIdList, newMemberEmailList);
+      try {
+        const response = await axios.put(`/api/plans/${state.id}`, requestBody);
+        return response;
+      } catch (error) {
+        return error;
+      }
+    };
+
     setModalData({ information: `변경사항을 저장하시겠어요?`, requestAPI } as INormalModal);
     openModal('normal');
   };
@@ -204,13 +139,13 @@ function Setting() {
         </label>
       </InputField>
       <InputField>
-        <label htmlFor="description">
+        <label htmlFor="intro">
           플랜 설명
           <input
             type="text"
-            id="description"
-            name="description"
-            value={planInfo.description}
+            id="intro"
+            name="intro"
+            value={planInfo.intro}
             onChange={changePlanInfo}
             placeholder="플랜을 설명해주세요"
           />
@@ -231,7 +166,7 @@ function Setting() {
         <ManageTeam
           type="setting"
           newMemberEmailList={newMemberEmailList}
-          existingMembers={planData.members}
+          existingMembers={state.members}
           deletedExistMemberIdList={deletedExistMemberIdList}
           handleDeleteNewMember={handleDeleteNewMember}
           handleDeleteExistMember={handleDeleteExistMember}

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import axios from 'axios';
 import { useLocation } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilState, useRecoilState } from 'recoil';
 import { IMember, INormalModal, ISelectOption } from 'types';
 
 import { Wrapper, Title, ManageTeamContainer, ImportantSetting, SettingItem, ButtonContainer, Button } from './styles';
@@ -14,7 +14,7 @@ import Modal from '@components/Modal';
 import SelectBox from '@components/SelectBox';
 import ToggleSwitch from '@components/ToggleSwitch';
 import useModal from '@hooks/useModal';
-import { modalDataState } from '@recoil/atoms';
+import { modalDataState, planTitlesState } from '@recoil/atoms';
 
 interface IPlanInfo {
   title: string;
@@ -34,6 +34,7 @@ function Setting() {
   const [isPublic, setIsPublic] = useState<boolean>(state.isPublic);
   const setModalData = useSetRecoilState(modalDataState);
   const { openModal } = useModal();
+  const [planTitles, setPlanTitles] = useRecoilState(planTitlesState);
 
   const options = state.members.map((member: IMember) => {
     return { id: member.id, name: member.name };
@@ -89,6 +90,7 @@ function Setting() {
         if (response.status === 204) {
           // eslint-disable-next-line no-alert
           window.alert(`플랜이 삭제되었습니다.`);
+          setPlanTitles(planTitles.filter((item) => item.id !== state.id));
           // TODO: 플랜 페이지로 이동
         }
       } catch (error) {

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useState } from 'react';
 
 import axios from 'axios';
@@ -91,7 +92,6 @@ function Setting() {
           // TODO: 플랜 페이지로 이동
         }
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.error('Error deleting plan:', error);
         throw error;
       }
@@ -101,20 +101,62 @@ function Setting() {
   };
 
   const handleSavePlan = () => {
-    const requestBody = {
-      ...planInfo,
-      isPublic,
-      ownerId: admin.id,
-    };
-    const requestAPI = async () => {
-      // TODO: 서버에 플랜 수정 요청
-      // TODO: 초대 및 강퇴
-      // console.log(deletedExistMemberIdList, newMemberEmailList);
+    const updatePlan = async () => {
+      const requestBody = {
+        ...planInfo,
+        isPublic,
+        ownerId: admin.id,
+      };
+
       try {
         const response = await axios.put(`/api/plans/${state.id}`, requestBody);
         return response;
       } catch (error) {
-        return error;
+        console.log(error);
+        throw error;
+      }
+    };
+
+    const inviteMembers = async () => {
+      try {
+        const response = await axios.put(`api/plans/invite/${state.id}`, newMemberEmailList);
+        console.log(response);
+      } catch (error) {
+        console.log(error);
+        throw error;
+      }
+    };
+
+    const deleteMembers = async () => {
+      const requestBody = {
+        kickingMemberIds: deletedExistMemberIdList,
+      };
+      try {
+        const response = await axios.put(`api/plans/kick/${state.id}`, requestBody);
+        console.log(response);
+      } catch (error) {
+        console.log(error);
+        throw error;
+      }
+    };
+
+    const requestAPI = async () => {
+      try {
+        const [updateResponse, inviteResponse, deleteResponse] = await Promise.all([
+          updatePlan(),
+          inviteMembers(),
+          deleteMembers(),
+        ]);
+
+        // TODO: 뭔가 한 번에 수정하는게 에러 처리하기 쉬울 듯 하다.
+        // 화면과도 로직이 어울리지 않는다.
+        // 멤버 초대, 강퇴는 204로 잘 온다.
+        console.log('Update Response:', updateResponse);
+        console.log('Invite Response:', inviteResponse);
+        console.log('Delete Response:', deleteResponse);
+      } catch (error) {
+        console.error('Error during API requests:', error);
+        throw error;
       }
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,9 +28,9 @@ export interface ITask {
 export interface IMember {
   id: number;
   name: string;
-  imgUrl?: string;
-  isAdmin: boolean;
-  email?: string;
+  imgSrc?: string;
+  admin: boolean;
+  mail?: string;
 }
 
 export interface ITab {


### PR DESCRIPTION
📌 Description

- 플랜 설정 페이지의 api를 연결했습니다.
  - 플랜 삭제, 초대, 강퇴는 잘 됩니다.
  - 플랜 정보 업데이트가 메서드 에러가 나서 못했습니다.
- 플랜 삭제 후 plan 페이지로 돌아가면 recoil에 저장된 currentPlanId는 여전히 삭제된 플랜의 id라서 플랜 정보를 불러오지 못하는 에러를 해결했습니다.
  - 삭제 후 planTitles에서 삭제된 플랜을 filter해서 setPlanTitles를 함
    - 삭제 후 바로 planTitles[0].id를 currentPlanId로 set하는 방법도 해보았지만 planTitles의 0를 삭제한 경우 없는 플랜을 불러와서 에러가 생김
- 플랜이 없다가 처음으로 1개를 생성 후 plan페이지로 돌아가면 recoil에 저장된 currentPlanId가 없어서 생성된 플랜 정보를 불러오지 못하는 버그를 수정했습니다.
  - 생성 후 setCurrentPlanId를 해줌

⚠️ 주의사항

- 플랜 수정시 변경사항 저장 버튼을 누르면 플랜 정보 업데이트, 팀원 초대, 팀원 강퇴 api 3개를 동시에 보내야합니다. 3개중 하나라도 실패했을 때 에러처리가 불편하고 어떤 건 저장되고 어떤 건 안되는 등의 문제가 있을 것 같아서 3개의 api를 1개의 api로 통일해야할 것 같습니다.
- 플랜 페이지에서 플랜이 없을 때 UI 작업을 해야합니다.

close #100