### PR TITLE
[#108] 로그인 시 토큰 저장 방식 변경 및 refresh 토큰으로 access 토큰 발급

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/styled-components": "^5.1.28",
     "axios": "^1.5.1",
     "http-proxy-middleware": "^2.0.6",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",

--- a/src/pages/CreatePlan/index.tsx
+++ b/src/pages/CreatePlan/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
@@ -19,6 +19,7 @@ import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
 import ToggleSwitch from '@components/ToggleSwitch';
 import { currentPlanIdState } from '@recoil/atoms';
+import { authenticate } from '@utils/auth';
 
 type PlanInfo = {
   title: string;
@@ -98,6 +99,10 @@ function CreatePlan() {
 
     return requestBody;
   };
+
+  useEffect(() => {
+    authenticate();
+  }, []);
 
   return (
     <Wrapper>

--- a/src/pages/GoogleOauthCallback/index.tsx
+++ b/src/pages/GoogleOauthCallback/index.tsx
@@ -5,8 +5,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Wrapper } from './styles';
 
-let accessToken: string | null = null;
-
 function GoogleOauthCallback() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -24,8 +22,7 @@ function GoogleOauthCallback() {
 
           // 서버로부터 받아온 데이터(profileUrl, accessToken, refreshToken, old 등을 저장한다.)
           if (data.registered) {
-            accessToken = data.accessToken;
-            axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+            axios.defaults.headers.common.Authorization = `Bearer ${data.accessToken}`;
             localStorage.setItem('profileUrl', data.profileUrl);
             navigate('/main');
           } else {

--- a/src/pages/GoogleOauthCallback/index.tsx
+++ b/src/pages/GoogleOauthCallback/index.tsx
@@ -5,6 +5,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Wrapper } from './styles';
 
+let accessToken: string | null = null;
+
 function GoogleOauthCallback() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -22,9 +24,8 @@ function GoogleOauthCallback() {
 
           // 서버로부터 받아온 데이터(profileUrl, accessToken, refreshToken, old 등을 저장한다.)
           if (data.registered) {
-            axios.defaults.headers.common.Authorization = `Bearer ${data.accessToken}`;
-            localStorage.setItem('accessToken', data.accessToken);
-            localStorage.setItem('refreshToken', data.refreshToken);
+            accessToken = data.accessToken;
+            axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
             localStorage.setItem('profileUrl', data.profileUrl);
             navigate('/main');
           } else {

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -58,9 +58,6 @@ interface IDragDropResult {
 }
 
 function Plan() {
-  useEffect(() => {
-    authenticate();
-  }, []);
   const { planId } = useParams();
   const [currentPlanId, setCurrentPlanId] = useRecoilState(currentPlanIdState);
   const [originalPlan, setOriginalPlan] = useState<IPlan | null>(null);
@@ -116,7 +113,7 @@ function Plan() {
         console.log(error);
       }
     };
-    getPlanTitles();
+    authenticate(getPlanTitles);
   }, []);
 
   useEffect(() => {

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -30,6 +30,7 @@ import MemberFilter from '@components/MemberFilter';
 import Modal from '@components/Modal';
 import { Tab, TasksContainer } from '@components/Tab';
 import { currentPlanIdState, labelsState, membersState, planTitlesState } from '@recoil/atoms';
+import { authenticate } from '@utils/auth';
 import registDND, { IDropEvent } from '@utils/drag';
 
 interface IPlan {
@@ -57,6 +58,9 @@ interface IDragDropResult {
 }
 
 function Plan() {
+  useEffect(() => {
+    authenticate();
+  }, []);
   const { planId } = useParams();
   const [currentPlanId, setCurrentPlanId] = useRecoilState(currentPlanIdState);
   const [originalPlan, setOriginalPlan] = useState<IPlan | null>(null);

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import axios from 'axios';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -15,6 +15,7 @@ import SelectBox from '@components/SelectBox';
 import ToggleSwitch from '@components/ToggleSwitch';
 import useModal from '@hooks/useModal';
 import { modalDataState, planTitlesState } from '@recoil/atoms';
+import { authenticate } from '@utils/auth';
 
 interface IPlanInfo {
   title: string;
@@ -126,6 +127,10 @@ function Setting() {
     setModalData({ information: `변경사항을 저장하시겠어요?`, requestAPI } as INormalModal);
     openModal('normal');
   };
+
+  useEffect(() => {
+    authenticate();
+  }, []);
 
   return (
     <Wrapper>

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -5,7 +5,8 @@ module.exports = (app) => {
   app.use(
     '/api', // proxy가 필요한 path prameter를 입력합니다.
     createProxyMiddleware({
-      target: 'http://localhost:8080', // 타겟이 되는 api url를 입력합니다.
+      // target: 'http://localhost:8080',
+      target: 'http://115.85.183.173:8080', // 타겟이 되는 api url를 입력합니다.
       changeOrigin: true, // 대상 서버 구성에 따라 호스트 헤더가 변경되도록 설정하는 부분입니다.
     }),
   );

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -13,7 +13,7 @@ const refreshAccessToken = async () => {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Error refreshing access token:', error);
-    // window.location.href = 'http://localhost:3000';
+    window.location.href = 'http://localhost:3000';
   }
 };
 
@@ -28,14 +28,16 @@ const isAccessTokenExpired = () => {
   return expirationTime < currentTime;
 };
 
-// Function to handle authentication logic
-export const authenticate = async () => {
+// 엑세스 토큰이 없거나 토큰이 만료되면 리프레시 토큰으로 엑세스 토큰 발행 및 api요청
+export const authenticate = async (apiRequest: () => Promise<void>) => {
   if (!accessToken || isAccessTokenExpired()) {
-    console.log(accessToken, 'hello');
     await refreshAccessToken();
   }
 
   axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+  // TODO: 엑세스 토큰 다시 발급하고 항상 api 요청을 날리지 않을 수도 있다.
+  //  api 요청 필요 없는 경우를 분리
+  apiRequest();
 };
 
 export { accessToken };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -8,8 +8,6 @@ const refreshAccessToken = async () => {
   try {
     const { data } = await axios.post('/api/auth/refresh-token');
     accessToken = data.accessToken;
-
-    // TODO: 리프레시 토큰으로 엑세스 토큰 요청 후에 새로운 리프레시가 쿠키에 저장되는지 확인이 필요
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Error refreshing access token:', error);
@@ -29,15 +27,17 @@ const isAccessTokenExpired = () => {
 };
 
 // 엑세스 토큰이 없거나 토큰이 만료되면 리프레시 토큰으로 엑세스 토큰 발행 및 api요청
-export const authenticate = async (apiRequest: () => Promise<void>) => {
+export const authenticate = async (apiRequest?: () => Promise<void>) => {
   if (!accessToken || isAccessTokenExpired()) {
     await refreshAccessToken();
   }
 
   axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
-  // TODO: 엑세스 토큰 다시 발급하고 항상 api 요청을 날리지 않을 수도 있다.
+  // refresh token 발급 직후 api 요청을 날려야 하는 경우 순서 보장을 위해 필요함
   //  api 요청 필요 없는 경우를 분리
-  apiRequest();
+  if (apiRequest) {
+    await apiRequest();
+  }
 };
 
 export { accessToken };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
+
+// eslint-disable-next-line import/no-mutable-exports
+let accessToken: string | null = null;
+
+const refreshAccessToken = async () => {
+  try {
+    const { data } = await axios.post('/api/auth/refresh-token');
+    accessToken = data.accessToken;
+
+    // TODO: 리프레시 토큰으로 엑세스 토큰 요청 후에 새로운 리프레시가 쿠키에 저장되는지 확인이 필요
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error refreshing access token:', error);
+    // window.location.href = 'http://localhost:3000';
+  }
+};
+
+export const getTokenExpirationTime = (token: string) => {
+  const decoded = jwtDecode(token);
+  return decoded.exp || 0;
+};
+
+const isAccessTokenExpired = () => {
+  const expirationTime = getTokenExpirationTime(accessToken || '');
+  const currentTime = Math.floor(Date.now() / 1000);
+  return expirationTime < currentTime;
+};
+
+// Function to handle authentication logic
+export const authenticate = async () => {
+  if (!accessToken || isAccessTokenExpired()) {
+    console.log(accessToken, 'hello');
+    await refreshAccessToken();
+  }
+
+  axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+};
+
+export { accessToken };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6883,6 +6883,11 @@ jsonpointer@^5.0.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 keyv@^4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.3.tgz#00873d2b046df737963157bd04f294ca818c9c25"


### PR DESCRIPTION
📌 Description
- access token을 변수로 저장했습니다.
- 새로고침하면 access token이 사라지므로 refresh token으로 access token 발급하도록 했습니다.
- 토큰의 만료기간이 끝날때도 refresh로 access를 다시 발급하도록 했습니다. (제대로 확인하지 않음)
- 플랜 페이지는 새로고침하자마자 모든 플랜 타이틀을 불러와야 하므로 authenticate함수가 apiRequest라는 api요청 함수를 받도록 했습니다.
  - 처음에는 플랜 페이지의 useEffect안에서 authenticate()하고 getPlanTitles()하면 되지 않을까 생각했지만 순서가 보장되지 않아 authenticate함수가 apiRequest를 받도록 수정했습니다.
  - 
⚠️ 주의사항
- access token의 만료 일시를 알고자 jwt-decode 라이브러리를 설치했습니다.
 - 저는 설치했을 때 eslint에서 import/no-extraneous-dependencies에러가 났었습니다.
 - 만약 위와 같은 에러가 난다면 yarn cache clean을 해주면 에러가 사라집니다.

- close #108