### PR TITLE
[#110] profileUrl 못 받아오는 문제 해결 및 회원가입시 헤더에 accessToken들어가도록 수정

### DIFF
--- a/src/pages/GoogleOauthCallback/index.tsx
+++ b/src/pages/GoogleOauthCallback/index.tsx
@@ -25,6 +25,7 @@ function GoogleOauthCallback() {
             localStorage.setItem('profileUrl', data.profileUrl);
             navigate('/main');
           } else {
+            localStorage.setItem('profileUrl', data.profileUrl);
             navigate('/signup', { state: data });
           }
         } catch (error) {

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -59,12 +59,8 @@ export default function SignUp() {
 
     try {
       const { data } = await registerUser(requestBody);
-
       // TODO: 이후 보안을 생각해서 방식을 변경해야 함
       setAuthorizationHeader(data.accessToken);
-      localStorage.setItem('accessToken', data.accessToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
-      localStorage.setItem('profileUrl', data.profileUrl);
       navigate('/main');
     } catch {
       throw Error('회원가입에 실패했습니다.');

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -8,7 +8,6 @@ let accessToken: string | null = null;
 const refreshAccessToken = async () => {
   try {
     const data = await requestNewToken();
-    console.log(data);
     accessToken = data.accessToken;
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
📌 Description
- 로그인할때 registered여부에 상관없이 localStorage에 profileUrl 넣어주도록 수정함
- 회원가입할때 로컬스토리지에 저장하지 않고 헤더에 accessToken만 들어가게 수정함

⚠️ 주의사항
- 문제는 refreshToken의 만료시간 때문에 계속 refresh로 access를 받아오는 함수가 실행되는 것 같습니다. (확실하지 않아서 확인이 필요할 것 같습니다.)

close #110