### PR TITLE
[#124, #125] react-query 적용 및 toasfity 알림창 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-icons": "^4.11.0",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^9.1.3",
     "recoil": "^0.7.7",
     "styled-components": "^6.0.8",
     "styled-reset": "^4.5.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 import { RecoilRoot } from 'recoil';
+import 'react-toastify/dist/ReactToastify.css';
 
 import Header from '@components/Header';
 import CreatePlan from '@pages/CreatePlan';
@@ -94,6 +96,17 @@ function App() {
       <RecoilRoot>
         <QueryClientProvider client={queryClient}>
           <RouterProvider router={router} />
+          <ToastContainer
+            position="top-right"
+            autoClose={1000}
+            hideProgressBar={false}
+            newestOnTop={false}
+            closeOnClick
+            rtl={false}
+            pauseOnFocusLoss
+            draggable
+            pauseOnHover
+          />
           <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       </RecoilRoot>

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -101,6 +101,11 @@ export const deleteTab = async (tabId: number, currentPlanId: number) => {
   return response;
 };
 
+export const dragTab = async (requestBody: { planId: number; targetId: number; newPrevId: number }) => {
+  const response = await api.post('api/tabs/change-order', requestBody);
+  return response;
+};
+
 /* Task */
 export const createTask = async (requestBody: {
   planId: number;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -143,6 +143,16 @@ export const deleteTask = async (taskId: number) => {
   return response;
 };
 
+export const dragTask = async (requestBody: {
+  planId: number;
+  targetTabId: number;
+  targetId: number;
+  newPrevId: number | null;
+}) => {
+  const response = await api.put('api/tasks/change-order', requestBody);
+  return response;
+};
+
 /* Label */
 export const createLabel = async (planId: number, name: string) => {
   const { headers } = await api.post('/api/labels', { planId, name });

--- a/src/components/Modal/AddTask.tsx
+++ b/src/components/Modal/AddTask.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 
 import { useRecoilValue } from 'recoil';
-import { IAddTaskModal, ILabel, ISelectOption, ITask } from 'types';
+import { IAddTaskModal, ILabel, ISelectOption } from 'types';
 
-import { createTask } from '@apis';
 import DateRange from '@components/DateRange';
 import LabelInput from '@components/LabelInput';
 import {
@@ -16,6 +15,7 @@ import {
 } from '@components/Modal/CommonModalStyles';
 import SelectBox from '@components/SelectBox';
 import useModal from '@hooks/useModal';
+import { useUpdateTask } from '@hooks/useUpdateTask';
 import { currentPlanIdState, membersState, modalDataState } from '@recoil/atoms';
 
 export default function AddTaskModal() {
@@ -27,6 +27,7 @@ export default function AddTaskModal() {
   const modalData = useRecoilValue(modalDataState) as IAddTaskModal;
   const currentPlanId = useRecoilValue(currentPlanIdState);
   const { closeModal } = useModal();
+  const { createTaskMutate } = useUpdateTask(currentPlanId);
 
   const options = members.map((member) => {
     return { id: member.id, name: member.name };
@@ -35,7 +36,6 @@ export default function AddTaskModal() {
   const submitAddTask = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    let newTaskId: number = -1;
     const startDate = dateRange ? dateRange[0] : null;
     const endDate = dateRange ? dateRange[1] : null;
     const requestBody = {
@@ -49,30 +49,8 @@ export default function AddTaskModal() {
       labels: selectedLabels.map((label) => label.id),
     };
 
-    try {
-      const response = await createTask(requestBody);
-      const splitLocation = response.headers.location.split('/');
-      newTaskId = +splitLocation[splitLocation.length - 1];
-      // eslint-disable-next-line
-      console.log(response);
-    } catch (error) {
-      // eslint-disable-next-line
-      alert('할 일을 추가하지 못했어요 :(');
-    }
+    createTaskMutate(requestBody);
 
-    const newTask: ITask = {
-      ...requestBody,
-      id: newTaskId,
-    };
-    // Plan 페이지 tasks 상태에 반영
-    modalData.addTaskHandler((prev) => {
-      const newTasks = { ...prev };
-      const currentTabId = modalData.tabId;
-      if (!newTasks[currentTabId]) newTasks[currentTabId] = [];
-      newTasks[modalData.tabId].push(newTask);
-      return newTasks;
-    });
-    // 모달 닫기
     closeModal();
   };
 

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -10,7 +10,6 @@ import { INormalModal, ITask } from 'types';
 
 import { Wrapper, Header, EditableTitle, Container, TaskList, Interactions, AddButton, TabDragBar } from './styles';
 
-// import { updateTabTitle } from '@apis';
 import Dropdown from '@components/Dropdown';
 import TaskItem from '@components/TaskItem';
 import useModal from '@hooks/useModal';
@@ -24,7 +23,6 @@ interface ITabProps {
   tasks: ITask[];
   onDeleteTab: () => void;
   onAddTask: Dispatch<SetStateAction<Record<number, ITask[]>>>;
-  onRemoveTask: (tabId: number, taskId: number) => void;
   onEditTask?: (tabId: number, taskId: number, editedTask: ITask) => void;
 }
 
@@ -39,7 +37,6 @@ interface ITaskContainerProps {
   id?: number;
   tasks?: ITask[];
   onAddTask?: Dispatch<SetStateAction<Record<number, ITask[]>>>;
-  onRemoveTask?: (tabId: number, taskId: number) => void;
   onEditTask?: (tabId: number, taskId: number, editedTask: ITask) => void; // TODO: ITask 타입 통일 필요
 }
 
@@ -112,7 +109,7 @@ function TabHeader({ id, initialTitle, onDeleteTab }: ITabHeaderProps) {
   );
 }
 
-export function TasksContainer({ id, tasks, onAddTask, onRemoveTask, onEditTask }: ITaskContainerProps) {
+export function TasksContainer({ id, tasks, onAddTask, onEditTask }: ITaskContainerProps) {
   const { openModal } = useModal();
   const setModalData = useSetRecoilState(modalDataState);
 
@@ -134,13 +131,7 @@ export function TasksContainer({ id, tasks, onAddTask, onRemoveTask, onEditTask 
             <TaskList {...provided.droppableProps} ref={provided.innerRef}>
               {tasks?.map((task, index) => (
                 // TODO: void 함수를 주는 것 외에 다른 방식을 생각해볼 필요가 있음
-                <TaskItem
-                  key={task.id}
-                  task={task}
-                  index={index}
-                  onRemoveTask={onRemoveTask || (() => {})}
-                  onEditTask={onEditTask || (() => {})}
-                />
+                <TaskItem key={task.id} task={task} index={index} onEditTask={onEditTask || (() => {})} />
               ))}
               {provided.placeholder}
             </TaskList>
@@ -159,11 +150,11 @@ export function TasksContainer({ id, tasks, onAddTask, onRemoveTask, onEditTask 
   );
 }
 
-export function Tab({ id, index, title, tasks, onDeleteTab, onAddTask, onRemoveTask, onEditTask }: ITabProps) {
+export function Tab({ id, index, title, tasks, onDeleteTab, onAddTask, onEditTask }: ITabProps) {
   return (
     <Wrapper className="dnd-tab" data-index={index} data-id={id}>
       <TabHeader id={id} initialTitle={title} onDeleteTab={onDeleteTab} />
-      <TasksContainer id={id} tasks={tasks} onAddTask={onAddTask} onRemoveTask={onRemoveTask} onEditTask={onEditTask} />
+      <TasksContainer id={id} tasks={tasks} onAddTask={onAddTask} onEditTask={onEditTask} />
     </Wrapper>
   );
 }

--- a/src/components/TaskItem/index.tsx
+++ b/src/components/TaskItem/index.tsx
@@ -10,39 +10,30 @@ import { IEditTaskModal, INormalModal, ITask } from 'types';
 
 import { ItemWrapper, ItemContainer, LabelField, LabelItem, InfoField, DateField, TaskRemoveButton } from './styles';
 
-import { deleteTask } from '@apis';
 import useModal from '@hooks/useModal';
-import { modalDataState } from '@recoil/atoms';
+import { useUpdateTask } from '@hooks/useUpdateTask';
+import { modalDataState, currentPlanIdState } from '@recoil/atoms';
 import { filteredLabelsSelector, memberSelector } from '@recoil/selectors';
 import { hashStringToColor } from '@utils';
 
 interface Props {
   task: ITask;
   index: number;
-  onRemoveTask: (tabId: number, taskId: number) => void;
   onEditTask: (tabId: number, taskId: number, editedTask: ITask) => void;
 }
 
-export default function TaskItem({ task, index, onRemoveTask, onEditTask }: Props) {
+export default function TaskItem({ task, index, onEditTask }: Props) {
   const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
   const assignee = useRecoilValue(memberSelector(task.assigneeId!));
   const setModalData = useSetRecoilState(modalDataState);
   const { openModal } = useModal();
-
+  const currentPlanId = useRecoilValue(currentPlanIdState);
+  const { deleteTaskMutate } = useUpdateTask(currentPlanId);
   if (!task.assigneeId) return null;
 
   const removeTaskHandler = () => {
     const requestAPI = async () => {
-      // TODO: 서버에 태스크 삭제 요청
-      try {
-        const response = await deleteTask(task.id);
-        // eslint-disable-next-line
-        console.log(response);
-      } catch (error) {
-        // eslint-disable-next-line
-        console.log(error);
-      }
-      onRemoveTask(task.tabId, task.id);
+      deleteTaskMutate({ taskId: task.id });
     };
     setModalData({ information: `"${task.title}"을 삭제할까요?`, requestAPI } as INormalModal);
     openModal('normal');

--- a/src/components/TaskItem/index.tsx
+++ b/src/components/TaskItem/index.tsx
@@ -24,12 +24,13 @@ interface Props {
 
 export default function TaskItem({ task, index, onEditTask }: Props) {
   const filteredLabels = useRecoilValue(filteredLabelsSelector(task.labels));
-  const assignee = useRecoilValue(memberSelector(task.assigneeId!));
+  const assignee = useRecoilValue(memberSelector(task.assigneeId));
   const setModalData = useSetRecoilState(modalDataState);
   const { openModal } = useModal();
   const currentPlanId = useRecoilValue(currentPlanIdState);
   const { deleteTaskMutate } = useUpdateTask(currentPlanId);
-  if (!task.assigneeId) return null;
+
+  // if (!task.assigneeId) return null;
 
   const removeTaskHandler = () => {
     const requestAPI = async () => {
@@ -82,7 +83,7 @@ export default function TaskItem({ task, index, onEditTask }: Props) {
                   </div>
                 )}
               </DateField>
-              <div>{assignee.name}</div>
+              <div>{assignee ? assignee.name : ''}</div>
             </InfoField>
           </ItemContainer>
           <TaskRemoveButton className="task-remove-button" type="button" onClick={removeTaskHandler}>

--- a/src/components/react-query/queryClient.ts
+++ b/src/components/react-query/queryClient.ts
@@ -1,21 +1,23 @@
+import useToast from '@hooks/useToast';
 import { MutationCache, QueryCache, QueryClient, QueryClientConfig } from '@tanstack/react-query';
 
 function errorHandler(type: 'query' | 'mutation', errorMsg: string) {
-  const action = type === 'query' ? 'load' : 'update';
-  // eslint-disable-next-line no-alert
-  window.alert(`could not ${action} data: ${errorMsg} error connecting to server`);
+  const { showToast } = useToast();
+  const action = type === 'query' ? '데이터를 받아오는 중' : '업데이트 중';
+  showToast(`${action} ${errorMsg}`, { type: 'error' });
 }
 
 export const queryClientConfig: QueryClientConfig = {
   defaultOptions: {
     queries: {
-      staleTime: 600000, // 10 minutes
-      // staleTime이 gcTime보다 긴 것은 말이 안 된다.
-      gcTime: 1800000, // 30 minutes
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
+      // staleTime: 600000, // 10 minutes
+      // // staleTime이 gcTime보다 긴 것은 말이 안 된다.
+      // gcTime: 1800000, // 30 minutes
+      // refetchOnWindowFocus: false,
+      // refetchOnReconnect: false,
     },
   },
+
   queryCache: new QueryCache({
     onError: (error) => errorHandler('query', error?.message),
   }),

--- a/src/components/react-query/queryClient.ts
+++ b/src/components/react-query/queryClient.ts
@@ -1,0 +1,31 @@
+import { MutationCache, QueryCache, QueryClient, QueryClientConfig } from '@tanstack/react-query';
+
+function errorHandler(type: 'query' | 'mutation', errorMsg: string) {
+  const action = type === 'query' ? 'load' : 'update';
+  // eslint-disable-next-line no-alert
+  window.alert(`could not ${action} data: ${errorMsg} error connecting to server`);
+}
+
+export const queryClientConfig: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      staleTime: 600000, // 10 minutes
+      // staleTime이 gcTime보다 긴 것은 말이 안 된다.
+      gcTime: 1800000, // 30 minutes
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  },
+  queryCache: new QueryCache({
+    onError: (error) => errorHandler('query', error?.message),
+  }),
+  mutationCache: new MutationCache({
+    onError: (error) => errorHandler('mutation', error?.message),
+  }),
+};
+
+export function generateQueryClient(config: QueryClientConfig) {
+  return new QueryClient(config);
+}
+
+export const queryClient = generateQueryClient(queryClientConfig);

--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -1,0 +1,88 @@
+import { useEffect, useMemo } from 'react';
+
+import { useSetRecoilState } from 'recoil';
+import { IPlan, ITask } from 'types';
+
+import { getPlanInfo } from '@apis';
+import { labelsState, membersState } from '@recoil/atoms';
+import { useQuery } from '@tanstack/react-query';
+
+interface UsePlan {
+  plan: IPlan;
+  tasksByTab: Record<number, ITask[]>;
+}
+
+export function usePlan(planId: number, selectedLabels: number[], selectedMembers: number[]): UsePlan {
+  const setMembers = useSetRecoilState(membersState);
+  const setLabels = useSetRecoilState(labelsState);
+  //   const queryClient = useQueryClient();
+
+  const commonOptions = {
+    staleTime: 0,
+    cacheTime: 300000, // 5 minutes
+  };
+
+  const fallback = {
+    id: 0,
+    title: '',
+    description: '',
+    public: false,
+    members: [],
+    tabOrder: [],
+    tabs: [],
+    labels: [],
+    tasks: [],
+  };
+
+  const { data: plan = fallback } = useQuery<IPlan, Error>({
+    queryKey: ['plan', planId],
+    queryFn: () => getPlanInfo(planId),
+    ...commonOptions,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    refetchInterval: 60000, // 60 seconds
+  });
+
+  const filteredPlan = useMemo(() => {
+    if (!plan) {
+      return fallback;
+    }
+
+    const filteredTasks = plan.tasks.filter((task: ITask) => {
+      const labelFilter = selectedLabels.length === 0 || task.labels.some((label) => selectedLabels.includes(label));
+      const memberFilter = selectedMembers.length === 0 || selectedMembers.includes(task.assigneeId!);
+
+      return labelFilter && memberFilter;
+    });
+
+    return { ...plan, tasks: filteredTasks };
+  }, [plan, selectedLabels, selectedMembers]);
+
+  useEffect(() => {
+    if (plan) {
+      const { members, labels } = plan;
+      setMembers(members);
+      setLabels(labels);
+    }
+  }, [plan, setMembers, setLabels]);
+
+  const tasksByTab = useMemo(() => {
+    const result: Record<number, ITask[]> = {};
+
+    if (filteredPlan) {
+      filteredPlan.tasks.forEach((task) => {
+        const { tabId } = task;
+        result[tabId] = result[tabId] || [];
+        result[tabId].push(task);
+      });
+    }
+
+    return result;
+  }, [filteredPlan]);
+
+  return {
+    plan: filteredPlan,
+    tasksByTab,
+  };
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,29 @@
+import { toast, ToastOptions } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+interface UseToastOptions extends ToastOptions {
+  type?: 'default' | 'success' | 'warning' | 'error';
+}
+
+const useToast = () => {
+  const showToast = (message: string, options: UseToastOptions) => {
+    const { type = 'default' } = options;
+    toast(message, {
+      type,
+      position: 'top-right',
+      autoClose: 1000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: true,
+      draggable: true,
+      progress: undefined,
+      theme: 'light',
+    });
+  };
+
+  return {
+    showToast,
+  };
+};
+
+export default useToast;

--- a/src/hooks/useUpdateTab.ts
+++ b/src/hooks/useUpdateTab.ts
@@ -1,0 +1,76 @@
+import { api } from '@apis';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface PlanInfo {
+  planId: number;
+  title: string;
+}
+
+interface PlanInfoWithTab extends PlanInfo {
+  tabId: number;
+}
+
+interface DeleteInfo {
+  planId: number;
+  tabId: number;
+}
+
+interface TabOrderInfo {
+  planId: number;
+  targetId: number;
+  newPrevId: number | null;
+}
+
+export const createNewTab = async (params: { planId: number; title: string }): Promise<void> => {
+  await api.post('/api/tabs', params);
+};
+
+export const updateTabTitle = async (params: { planId: number; tabId: number; title: string }) => {
+  await api.patch(`/api/tabs/${params.tabId}/title`, { planId: params.planId, title: params.title });
+};
+
+export const deleteTab = async (params: { planId: number; tabId: number }) => {
+  await api.delete(`/api/tabs/${params.tabId}?planId=${params.planId}`);
+};
+
+export const dragTab = async (params: { planId: number; targetId: number; newPrevId: number | null }) => {
+  await api.post('api/tabs/change-order', params);
+};
+
+export function useUpdateTab(planId: number) {
+  const queryClient = useQueryClient();
+
+  const { mutate: createTabMutate } = useMutation({
+    mutationFn: (data: PlanInfo) => createNewTab(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  const { mutate: updateTabTitleMutate } = useMutation({
+    mutationFn: (data: PlanInfoWithTab) => updateTabTitle(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  const { mutate: deleteTabMutate } = useMutation({
+    mutationFn: (data: DeleteInfo) => deleteTab(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  const { mutate: dragTabMutate } = useMutation({
+    mutationFn: (data: TabOrderInfo) => dragTab(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  return { createTabMutate, updateTabTitleMutate, deleteTabMutate, dragTabMutate };
+}

--- a/src/hooks/useUpdateTab.ts
+++ b/src/hooks/useUpdateTab.ts
@@ -1,3 +1,5 @@
+import useToast from './useToast';
+
 import { api } from '@apis';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -39,12 +41,14 @@ export const dragTab = async (params: { planId: number; targetId: number; newPre
 
 export function useUpdateTab(planId: number) {
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
 
   const { mutate: createTabMutate } = useMutation({
     mutationFn: (data: PlanInfo) => createNewTab(data),
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('탭이 추가되었습니다.', { type: 'success' });
     },
   });
 
@@ -53,6 +57,7 @@ export function useUpdateTab(planId: number) {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('탭 이름이 변경되었습니다.', { type: 'success' });
     },
   });
 
@@ -61,6 +66,7 @@ export function useUpdateTab(planId: number) {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('탭이 삭제되었습니다.', { type: 'success' });
     },
   });
 
@@ -69,6 +75,7 @@ export function useUpdateTab(planId: number) {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('탭 순서가 변경되었습니다.', { type: 'success' });
     },
   });
 

--- a/src/hooks/useUpdateTask.ts
+++ b/src/hooks/useUpdateTask.ts
@@ -1,0 +1,87 @@
+import { api } from '@apis';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface TaskInfo {
+  planId: number;
+  tabId: number;
+  assigneeId: number | undefined;
+  title: string;
+  description: string;
+  startDate: string | null;
+  endDate: string | null;
+  labels: number[];
+}
+interface UpdateTaskInfo extends TaskInfo {
+  taskId: number;
+}
+
+interface DragInfo {
+  planId: number;
+  targetTabId: number;
+  targetId: number;
+  newPrevId: number | null;
+}
+
+export const createNewTask = async (params: TaskInfo): Promise<void> => {
+  await api.post('/api/tasks', params);
+};
+
+export const updateTask = async (params: UpdateTaskInfo) => {
+  await api.put(`/api/tasks/${params.taskId}`, {
+    planId: params.planId,
+    tabId: params.tabId,
+    assigneeId: params.assigneeId,
+    title: params.title,
+    description: params.description,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    labels: params.labels,
+  });
+};
+
+export const deleteTask = async (params: { taskId: number }) => {
+  await api.delete(`/api/tasks/${params.taskId}`);
+};
+
+export const dragTask = async (params: DragInfo) => {
+  const response = await api.put('api/tasks/change-order', params);
+  return response;
+};
+
+export function useUpdateTask(planId: number) {
+  const queryClient = useQueryClient();
+
+  const { mutate: createTaskMutate } = useMutation({
+    mutationFn: (data: TaskInfo) => createNewTask(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  const { mutate: updateTaskMutate } = useMutation({
+    mutationFn: (data: UpdateTaskInfo) => updateTask(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  const { mutate: deleteTaskMutate } = useMutation({
+    mutationFn: (data: { taskId: number }) => deleteTask(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  const { mutate: dragTaskMutate } = useMutation({
+    mutationFn: (data: DragInfo) => dragTask(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+
+  return { createTaskMutate, updateTaskMutate, deleteTaskMutate, dragTaskMutate };
+}

--- a/src/hooks/useUpdateTask.ts
+++ b/src/hooks/useUpdateTask.ts
@@ -1,3 +1,5 @@
+import useToast from './useToast';
+
 import { api } from '@apis';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -50,12 +52,14 @@ export const dragTask = async (params: DragInfo) => {
 
 export function useUpdateTask(planId: number) {
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
 
   const { mutate: createTaskMutate } = useMutation({
     mutationFn: (data: TaskInfo) => createNewTask(data),
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('태스크가 추가되었습니다.', { type: 'success' });
     },
   });
 
@@ -64,6 +68,7 @@ export function useUpdateTask(planId: number) {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('태스크가 수정되었습니다', { type: 'success' });
     },
   });
 
@@ -72,6 +77,7 @@ export function useUpdateTask(planId: number) {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('태스크가 삭제되었습니다.', { type: 'success' });
     },
   });
 
@@ -80,6 +86,7 @@ export function useUpdateTask(planId: number) {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('태스크 순서가 변경되었습니다.', { type: 'success' });
     },
   });
 

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -63,9 +63,9 @@ function Plan() {
     tasks: [],
   };
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
+  const [tasks, setTasks] = useState<Record<number, ITask[]>>({});
   const { planId } = useParams();
   const [currentPlanId, setCurrentPlanId] = useRecoilState(currentPlanIdState);
-  const [tasks, setTasks] = useState<Record<number, ITask[]>>({});
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [newTabTitle, setNewTabTitle] = useState<string>('');
   const [isAddingTab, setIsAddingTab] = useState<boolean>(false);
@@ -175,14 +175,8 @@ function Plan() {
     }
   };
 
-  const handleDeleteTask = (tabId: number, taskId: number) => {
-    if (tasks) {
-      setTasks((prev) => {
-        const newTasks = { ...prev };
-        newTasks[tabId] = newTasks[tabId].filter((task) => task.id !== taskId);
-        return newTasks;
-      });
-    }
+  const handleDeleteTab = async (tabId: number) => {
+    deleteTabMutate({ planId: currentPlanId, tabId });
   };
 
   const handleEditTask = (tabId: number, taskId: number, editedTask: ITask) => {
@@ -197,30 +191,6 @@ function Plan() {
       });
     }
   };
-
-  const handleDeleteTab = async (tabId: number) => {
-    deleteTabMutate({ planId: currentPlanId, tabId });
-  };
-
-  const handleChangeLabel = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const clickedLabel = Number(e.target.value);
-    setSelectedLabel((prev) => {
-      if (prev.includes(clickedLabel)) {
-        return prev.filter((item) => item !== clickedLabel);
-      }
-      return [...prev, clickedLabel];
-    });
-  };
-
-  const handleChangeMember = async (memberId: number) => {
-    setSelectedMembers((prev) => {
-      if (prev.includes(memberId)) {
-        return prev.filter((item) => item !== memberId);
-      }
-      return [...prev, memberId];
-    });
-  };
-
   const onDragEnd = (result: IDragDropResult) => {
     const { destination, source } = result;
 
@@ -259,6 +229,25 @@ function Plan() {
         [destination.droppableId]: newFinish,
       };
       return newTasks;
+    });
+  };
+
+  const handleChangeLabel = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const clickedLabel = Number(e.target.value);
+    setSelectedLabel((prev) => {
+      if (prev.includes(clickedLabel)) {
+        return prev.filter((item) => item !== clickedLabel);
+      }
+      return [...prev, clickedLabel];
+    });
+  };
+
+  const handleChangeMember = async (memberId: number) => {
+    setSelectedMembers((prev) => {
+      if (prev.includes(memberId)) {
+        return prev.filter((item) => item !== memberId);
+      }
+      return [...prev, memberId];
     });
   };
 
@@ -340,7 +329,7 @@ function Plan() {
                     onDeleteTab={() => handleDeleteTab(item.id)}
                     tasks={tasksByTab[item.id]}
                     onAddTask={setTasks}
-                    onRemoveTask={handleDeleteTask}
+                    // onRemoveTask={handleDeleteTask}
                     onEditTask={handleEditTask}
                   />
                 );

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -8,7 +8,6 @@ import { IoIosStarOutline } from 'react-icons/io';
 import { SlPlus } from 'react-icons/sl';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
-// import { ITask, ITab, IMember, ILabel } from 'types';
 import { ITask, ITab } from 'types';
 
 import {
@@ -34,22 +33,9 @@ import Modal from '@components/Modal';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import { Tab, TasksContainer } from '@components/Tab';
 import { usePlan } from '@hooks/usePlan';
-// import { currentPlanIdState, labelsState, membersState, planTitlesState, accessTokenState } from '@recoil/atoms';
 import { currentPlanIdState, planTitlesState, accessTokenState } from '@recoil/atoms';
 import { authenticate } from '@utils/auth';
 import registDND, { IDropEvent } from '@utils/drag';
-
-// interface IPlan {
-//   id: number;
-//   title: string;
-//   description: string;
-//   public: boolean;
-//   members: IMember[];
-//   tabOrder: number[];
-//   tabs: ITab[];
-//   labels: ILabel[];
-//   tasks: ITask[];
-// }
 
 interface IDragDropResult {
   source: {
@@ -78,7 +64,6 @@ function Plan() {
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
   const { planId } = useParams();
   const [currentPlanId, setCurrentPlanId] = useRecoilState(currentPlanIdState);
-  // const [originalPlan, setOriginalPlan] = useState<IPlan | null>(null);
   const [tasks, setTasks] = useState<Record<number, ITask[]>>({});
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [newTabTitle, setNewTabTitle] = useState<string>('');
@@ -86,12 +71,10 @@ function Plan() {
 
   const [selectedLabels, setSelectedLabel] = useState<number[]>([]);
   const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
-  // const setMembers = useSetRecoilState(membersState);
-  // const setLabels = useSetRecoilState(labelsState);
   const [planTitles, setPlanTitles] = useRecoilState(planTitlesState);
 
   const navigate = useNavigate();
-  console.log(planTitles);
+
   const { plan, tasksByTab } = usePlan(currentPlanId, selectedLabels, selectedMembers);
 
   useEffect(() => {
@@ -110,36 +93,10 @@ function Plan() {
   }, []);
 
   useEffect(() => {
-    // 플랜 4가 삭제되어도 recoil은 4를 갖고 있어서 fetch할때 에러가 난다.
-    // setting에서 플랜 삭제시 planTitles에서 4를 없앤다.
-    // setting에서 플랜 삭제시 바로 currentPlanId를 planTitles의 0로 바꾸고 싶었지만
-    // 0번째를 삭제한 경우 planTitle이 변화가 없기 떄문에 currentPlanId가 삭제된 id와 동일해서 못 받아온다.
     if (planId === undefined && planTitles.length > 0) {
       setCurrentPlanId(planTitles[0].id);
     }
-    // const fetchData = async () => {
-    //   // planTitles가 빈 배열인 경우 데이터를 가져올 데이터가 없다.
-    //   if (currentPlanId === -1 || planTitles.length === 0) return;
-    //   try {
-    //     const data = await getPlanInfo(planId === undefined ? planTitles[0].id : currentPlanId);
-    //     setMembers(data.members);
-    //     setLabels(data.labels);
-    //     // setOriginalPlan(data); // 원래의 플랜 데이터 저장
-    //     // filterAndSetPlan(data, selectedLabels, selectedMembers);
-    //   } catch (error) {
-    //     throw new Error('플랜 정보를 가져오는데 실패했습니다.');
-    //   }
-    // };
-    // fetchData();
-    // 의존성에 planTitles를 넣어줘야 플랜이 없다가 생성했을때 플랜페이지로 돌아와서 plan정보를 받아옴
   }, [planId, planTitles]);
-
-  // useEffect(() => {
-  //   if (originalPlan) {
-  //     // 원래 플랜 데이터를 기반으로 다시 필터링
-  //     // filterAndSetPlan(originalPlan, selectedLabels, selectedMembers);
-  //   }
-  // }, [selectedLabels, selectedMembers, originalPlan]);
 
   const handleDrag = ({ source, destination }: IDropEvent) => {
     if (!destination) return;

--- a/src/recoil/selectors.ts
+++ b/src/recoil/selectors.ts
@@ -3,10 +3,10 @@ import { ILabel, IMember } from 'types';
 
 import { labelsState, membersState } from '@recoil/atoms';
 
-export const memberSelector = selectorFamily<IMember, number>({
+export const memberSelector = selectorFamily<IMember, number | undefined>({
   key: 'filteredMember',
   get:
-    (memberId: number) =>
+    (memberId: number | undefined) =>
     ({ get }) =>
       get(membersState).find((member) => member.id === memberId)!,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,6 +3711,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -8642,6 +8647,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-toastify@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.3.tgz#1e798d260d606f50e0fab5ee31daaae1d628c5ff"
+  integrity sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
📌 Description
- plan 받아오기, task CRUD, tab CRUD 요청을 react-query로 전환했습니다.
  - usePlan, useUpdateTask, useUpdateTab 훅으로 만들어 두었습니다.
  - 이에 따라 불필요한 plan 상태 업데이트는 제거했습니다.
- TaskItem에서 assignee가 null이여도 보이도록 수정했습니다. ( task 수정 api가 assigneeId를 보내도 다시 플랜 정보를 받아보면 null로 되더라구요!, 그리고 description 정보는 아예 포함되어 있지 않습니다. )
- toastify로 알림을 구현했습니다. (useToast 훅으로 갖다 쓰면 됩니다.)
  - api 요청 성공시 success는 되는데(CORS 에러 없는 api가 탭 이름 변경 뿐이라 확인은 이것밖에 안됩니다.) onError는 아직 안 됩니다. 
    - onError를 queryClient에서 공통으로 주려고 했는데 문제가 있는 것 같습니다.

⚠️ 주의사항
-  지금 api들이 헤더 멀티플 벨류 문제로 204, 201이 와도 CORS 에러가 나서 버그가 발생하거나 확인이 안되는 부분이 좀 많습니다.
  - 특히 task, tab CRUD 요청 후 setTasks 부분을 수정해야 하는데 고민 중입니다.
    - api 요청이 성공하면 ["plan", planId] 키를 가진 플랜 정보를 무효화해서 다시 받아오기 때문에 사실 setTasks가 필요 없을 것 같기는 합니다. 제 생각이라서 확인을 해봐야 확신할 수 있을 것 같아요. 
    - 그런데 혹시 몰라서 남겨 두었습니다. ( 제 생각이 틀리거나 만약 낙관적 업데이트를 추후에 하고 싶은 경우?를 위해서)
- plan 삭제, 변경 등의 다른 api도 react-query로 변경하겠습니다. 
- 그리고 planId 부분도 리팩토링이 필요할 것 같습니다.
- registDND에 버그가 많은 것 같아서 탭도 beautiful dnd로 변경해야 할 것 같습니다.
- planReducer, taskReducer는 복잡함만 추가되는 것 같고 react-query를 쓰면 해결될 부분이 많을 것 같아 일단 제외해두었습니다.

close #124 
close #125