### PR TITLE
[#127] 기존의 탭 드래그앤드롭 하던 registDND 함수 제외 후 beautiful-dnd라이브러리로 전환

### DIFF
--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useRef, Dispatch, SetStateAction } from 'react';
 
-import { Droppable } from 'react-beautiful-dnd';
+import { Draggable, Droppable } from 'react-beautiful-dnd';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { INormalModal, ITask } from 'types';
 
@@ -126,7 +126,7 @@ export function TasksContainer({ id, tasks, onAddTask, onEditTask }: ITaskContai
   return (
     <Container>
       {id ? (
-        <Droppable droppableId={id.toString()}>
+        <Droppable droppableId={`task-${id}`}>
           {(provided) => (
             <TaskList {...provided.droppableProps} ref={provided.innerRef}>
               {tasks?.map((task, index) => (
@@ -152,9 +152,19 @@ export function TasksContainer({ id, tasks, onAddTask, onEditTask }: ITaskContai
 
 export function Tab({ id, index, title, tasks, onDeleteTab, onAddTask, onEditTask }: ITabProps) {
   return (
-    <Wrapper className="dnd-tab" data-index={index} data-id={id}>
-      <TabHeader id={id} initialTitle={title} onDeleteTab={onDeleteTab} />
-      <TasksContainer id={id} tasks={tasks} onAddTask={onAddTask} onEditTask={onEditTask} />
-    </Wrapper>
+    // <Wrapper className="dnd-tab" data-index={index} data-id={id}>
+    <Draggable draggableId={`tab-${id}`} key={`tab-${id}`} index={index}>
+      {(provided) => (
+        <Wrapper
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          ref={provided.innerRef}
+          // isDragging={snapshot.isDragging}
+        >
+          <TabHeader id={id} initialTitle={title} onDeleteTab={onDeleteTab} />
+          <TasksContainer id={id} tasks={tasks} onAddTask={onAddTask} onEditTask={onEditTask} />
+        </Wrapper>
+      )}
+    </Draggable>
   );
 }

--- a/src/components/TaskItem/index.tsx
+++ b/src/components/TaskItem/index.tsx
@@ -49,7 +49,7 @@ export default function TaskItem({ task, index, onEditTask }: Props) {
   };
 
   return (
-    <Draggable draggableId={task.id.toString()} index={index}>
+    <Draggable draggableId={`task-${task.id}`} index={index}>
       {(provided) => (
         <ItemWrapper>
           <ItemContainer

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, { useEffect, useState, useRef } from 'react';
 
-import { DragDropContext, OnDragEndResponder } from 'react-beautiful-dnd';
+import { Droppable, DragDropContext, OnDragEndResponder } from 'react-beautiful-dnd';
 import { CiSettings } from 'react-icons/ci';
 import { IoIosStarOutline } from 'react-icons/io';
 import { SlPlus } from 'react-icons/sl';
@@ -23,6 +23,7 @@ import {
   TabContainer,
   EmptyPlanContainer,
   EmptyPlanContents,
+  // TabContainer,
 } from './styles';
 
 import { getAllPlanTitles } from '@apis';
@@ -36,7 +37,8 @@ import { usePlan } from '@hooks/usePlan';
 import { useUpdateTab } from '@hooks/useUpdateTab';
 import { currentPlanIdState, planTitlesState, accessTokenState } from '@recoil/atoms';
 import { authenticate } from '@utils/auth';
-import registDND, { IDropEvent } from '@utils/drag';
+// import registDND, { IDropEvent } from '@utils/drag';
+// import { IDropEvent } from '@utils/drag';
 
 interface IDragDropResult {
   source: {
@@ -63,6 +65,7 @@ function Plan() {
     tasks: [],
   };
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
+  const [sortedTabs, setSortedTabs] = useState<{ id: number; title: string; taskOrder?: number[] }[]>([]);
   const [tasks, setTasks] = useState<Record<number, ITask[]>>({});
   const { planId } = useParams();
   const [currentPlanId, setCurrentPlanId] = useRecoilState(currentPlanIdState);
@@ -73,14 +76,25 @@ function Plan() {
   const [selectedLabels, setSelectedLabel] = useState<number[]>([]);
   const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
   const [planTitles, setPlanTitles] = useRecoilState(planTitlesState);
+  const { plan, tasksByTab } = usePlan(currentPlanId, selectedLabels, selectedMembers);
   const { createTabMutate, deleteTabMutate, dragTabMutate } = useUpdateTab(
     // TODO: planId 리팩토링 필요
-    planId === undefined ? -1 : Number(planId),
+    Number(plan.id),
   );
 
   const navigate = useNavigate();
 
-  const { plan, tasksByTab } = usePlan(currentPlanId, selectedLabels, selectedMembers);
+  useEffect(() => {
+    setTasks(tasksByTab);
+    const tabById: Record<number, ITab> = {};
+    plan.tabs.forEach((tab) => {
+      tabById[tab.id] = tab;
+    });
+    const newSortedTabs = plan.tabOrder.map((tabId) => {
+      return tabById[tabId];
+    });
+    setSortedTabs(newSortedTabs);
+  }, [plan]);
 
   useEffect(() => {
     const getPlanTitles = async () => {
@@ -103,37 +117,31 @@ function Plan() {
     }
   }, [planId, planTitles]);
 
-  const handleDrag = ({ source, destination }: IDropEvent) => {
-    if (!destination) return;
-    if (source.index === destination.index) return;
+  // const handleDrag = ({ source, destination }: IDropEvent) => {
+  //   if (!destination) return;
+  //   if (source.index === destination.index) return;
 
-    if (!plan) return;
-    const newTabOrder = [...plan.tabOrder];
-    const draggedTabIndex = newTabOrder.indexOf(source.id);
-    const targetTabIndex = newTabOrder.indexOf(destination.id);
-    newTabOrder.splice(draggedTabIndex, 1);
-    newTabOrder.splice(targetTabIndex, 0, source.id);
+  //   if (!plan) return;
+  //   const newTabOrder = [...plan.tabOrder];
+  //   const draggedTabIndex = newTabOrder.indexOf(source.id);
+  //   const targetTabIndex = newTabOrder.indexOf(destination.id);
+  //   newTabOrder.splice(draggedTabIndex, 1);
+  //   newTabOrder.splice(targetTabIndex, 0, source.id);
 
-    const prevIndex = newTabOrder.indexOf(source.id) - 1;
-    const requestData = {
-      planId: plan.id,
-      targetId: source.id,
-      newPrevId: prevIndex === -1 ? null : newTabOrder[prevIndex],
-    };
+  //   const prevIndex = newTabOrder.indexOf(source.id) - 1;
+  //   const requestData = {
+  //     planId: plan.id,
+  //     targetId: source.id,
+  //     newPrevId: prevIndex === -1 ? null : newTabOrder[prevIndex],
+  //   };
 
-    dragTabMutate(requestData);
-  };
+  //   dragTabMutate(requestData);
+  // };
 
-  useEffect(() => {
-    const clear = registDND(handleDrag);
-    return () => clear();
-  }, [tasksByTab]); // Adjust the dependencies based on your use case
-
-  const tabById: Record<number, ITab> = {};
-  plan.tabs.forEach((tab) => {
-    tabById[tab.id] = tab;
-  });
-  const sortedTabs = plan.tabOrder.map((tabId) => tabById[tabId]);
+  // useEffect(() => {
+  //   const clear = registDND(handleDrag);
+  //   return () => clear();
+  // }, [tasksByTab]); // Adjust the dependencies based on your use case
 
   const handleStartAddingTab = () => {
     setIsAddingTab(true);
@@ -192,44 +200,66 @@ function Plan() {
     }
   };
   const onDragEnd = (result: IDragDropResult) => {
-    const { destination, source } = result;
+    const { destination, source, draggableId } = result;
 
-    if (!destination) return;
+    // console.log(source, destination, draggableId);
+    const sourceType = source.droppableId.split('-')[0];
 
-    if (destination.droppableId === source.droppableId && destination.index === source.index) return;
+    // console.log(sourceType, dragTabMutate);
 
-    const start = tasks[+source.droppableId];
-    const finish = tasks[+destination.droppableId];
+    if (sourceType === 'tab') {
+      const newTabOrder = [...plan.tabOrder];
+      newTabOrder.splice(source.index, 1);
+      newTabOrder.splice(destination.index, 0, Number(draggableId.split('-')[1]));
 
-    const updatedTask = start[source.index];
-    start.splice(source.index, 1);
+      const prevIndex = newTabOrder.indexOf(Number(draggableId.split('-')[1])) - 1;
+      const requestData = {
+        planId: plan.id,
+        targetId: Number(draggableId.split('-')[1]),
+        newPrevId: prevIndex === -1 ? null : newTabOrder[prevIndex],
+      };
 
-    if (start === finish) {
-      start.splice(destination.index, 0, updatedTask);
+      // setSortedTabs(newTabOrder);
 
-      setTasks((prev) => {
-        const newTasks = { ...prev };
-        newTasks[+source.droppableId] = [...start];
-        return newTasks;
-      });
-      return;
+      console.log(prevIndex, requestData);
+      dragTabMutate(requestData);
+      console.log(dragTabMutate);
     }
 
-    updatedTask.tabId = +destination.droppableId;
-    finish.splice(destination.index, 0, updatedTask);
+    if (sourceType === 'task') {
+      if (!destination) return;
 
-    // TODO: order가 추가될 수 있음
-    const newStart = [...start];
-    const newFinish = [...finish];
+      if (destination.droppableId === source.droppableId && destination.index === source.index) return;
 
-    setTasks((prev) => {
-      const newTasks = {
-        ...prev,
-        [source.droppableId]: newStart,
-        [destination.droppableId]: newFinish,
-      };
-      return newTasks;
-    });
+      const start = tasks[+Number(source.droppableId.split('-')[1])];
+      const finish = tasks[+Number(destination.droppableId.split('-')[1])] || [];
+      const updatedTask = start[source.index];
+      // console.log(start, finish, updatedTask);
+
+      start.splice(source.index, 1);
+      if (start === finish) {
+        start.splice(destination.index, 0, updatedTask);
+        setTasks((prev) => {
+          const newTasks = { ...prev };
+          newTasks[+Number(source.droppableId.split('-')[1])] = [...start];
+          return newTasks;
+        });
+        return;
+      }
+      updatedTask.tabId = +Number(destination.droppableId.split('-')[1]);
+      finish.splice(destination.index, 0, updatedTask);
+      // TODO: order가 추가될 수 있음
+      const newStart = [...start];
+      const newFinish = [...finish];
+      setTasks((prev) => {
+        const newTasks = {
+          ...prev,
+          [Number(source.droppableId.split('-')[1])]: newStart,
+          [Number(destination.droppableId.split('-')[1])]: newFinish,
+        };
+        return newTasks;
+      });
+    }
   };
 
   const handleChangeLabel = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -316,44 +346,53 @@ function Plan() {
             </div>
           </UtilContainer>
         </TopContainer>
-        <TabGroup data-droppable-id={1} className="droppable">
+        {/* <TabGroup data-droppable-id={1} className="droppable"> */}
+        <TabContainer>
           <DragDropContext onDragEnd={onDragEnd as OnDragEndResponder}>
-            <TabContainer>
-              {sortedTabs.map((item, index) => {
-                return (
-                  <Tab
-                    id={item.id}
-                    key={item.id}
-                    index={index}
-                    title={item.title}
-                    onDeleteTab={() => handleDeleteTab(item.id)}
-                    tasks={tasksByTab[item.id]}
-                    onAddTask={setTasks}
-                    // onRemoveTask={handleDeleteTask}
-                    onEditTask={handleEditTask}
-                  />
-                );
-              })}
-
-              {isAddingTab && (
-                <TabWrapper>
-                  <input
-                    type="text"
-                    ref={inputRef}
-                    value={newTabTitle}
-                    onChange={(e) => setNewTabTitle(e.target.value)}
-                    onBlur={handleAddTab}
-                    onKeyDown={handleInputKeyDown}
-                  />
-                  <TasksContainer />
-                </TabWrapper>
+            <Droppable direction="horizontal" droppableId="tab" type="tab">
+              {(provided) => (
+                <TabGroup
+                  ref={provided.innerRef}
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...provided.droppableProps}
+                >
+                  {sortedTabs.map((item, index) => {
+                    return (
+                      <Tab
+                        id={item.id}
+                        key={item.id}
+                        index={index}
+                        title={item.title}
+                        onDeleteTab={() => handleDeleteTab(item.id)}
+                        tasks={tasks[item.id] || []}
+                        onAddTask={setTasks}
+                        // onRemoveTask={handleDeleteTask}
+                        onEditTask={handleEditTask}
+                      />
+                    );
+                  })}
+                  {isAddingTab && (
+                    <TabWrapper>
+                      <input
+                        type="text"
+                        ref={inputRef}
+                        value={newTabTitle}
+                        onChange={(e) => setNewTabTitle(e.target.value)}
+                        onBlur={handleAddTab}
+                        onKeyDown={handleInputKeyDown}
+                      />
+                      <TasksContainer />
+                    </TabWrapper>
+                  )}
+                  {provided.placeholder}
+                </TabGroup>
               )}
-            </TabContainer>
+            </Droppable>
           </DragDropContext>
           <AddTabButton>
             <SlPlus size={35} color="#8993A1" onClick={handleStartAddingTab} />
           </AddTabButton>
-        </TabGroup>
+        </TabContainer>
       </MainContainer>
       <Modal />
     </Wrapper>

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -23,7 +23,6 @@ import {
   TabContainer,
   EmptyPlanContainer,
   EmptyPlanContents,
-  // TabContainer,
 } from './styles';
 
 import { getAllPlanTitles } from '@apis';
@@ -37,8 +36,6 @@ import { usePlan } from '@hooks/usePlan';
 import { useUpdateTab } from '@hooks/useUpdateTab';
 import { currentPlanIdState, planTitlesState, accessTokenState } from '@recoil/atoms';
 import { authenticate } from '@utils/auth';
-// import registDND, { IDropEvent } from '@utils/drag';
-// import { IDropEvent } from '@utils/drag';
 
 interface IDragDropResult {
   source: {
@@ -117,32 +114,6 @@ function Plan() {
     }
   }, [planId, planTitles]);
 
-  // const handleDrag = ({ source, destination }: IDropEvent) => {
-  //   if (!destination) return;
-  //   if (source.index === destination.index) return;
-
-  //   if (!plan) return;
-  //   const newTabOrder = [...plan.tabOrder];
-  //   const draggedTabIndex = newTabOrder.indexOf(source.id);
-  //   const targetTabIndex = newTabOrder.indexOf(destination.id);
-  //   newTabOrder.splice(draggedTabIndex, 1);
-  //   newTabOrder.splice(targetTabIndex, 0, source.id);
-
-  //   const prevIndex = newTabOrder.indexOf(source.id) - 1;
-  //   const requestData = {
-  //     planId: plan.id,
-  //     targetId: source.id,
-  //     newPrevId: prevIndex === -1 ? null : newTabOrder[prevIndex],
-  //   };
-
-  //   dragTabMutate(requestData);
-  // };
-
-  // useEffect(() => {
-  //   const clear = registDND(handleDrag);
-  //   return () => clear();
-  // }, [tasksByTab]); // Adjust the dependencies based on your use case
-
   const handleStartAddingTab = () => {
     setIsAddingTab(true);
     setNewTabTitle('');
@@ -202,16 +173,18 @@ function Plan() {
   const onDragEnd = (result: IDragDropResult) => {
     const { destination, source, draggableId } = result;
 
-    // console.log(source, destination, draggableId);
     const sourceType = source.droppableId.split('-')[0];
 
-    // console.log(sourceType, dragTabMutate);
-
     if (sourceType === 'tab') {
-      const newTabOrder = [...plan.tabOrder];
-      newTabOrder.splice(source.index, 1);
-      newTabOrder.splice(destination.index, 0, Number(draggableId.split('-')[1]));
+      const newSortedTabs = [...sortedTabs];
+      newSortedTabs.splice(source.index, 1);
+      newSortedTabs.splice(
+        destination.index,
+        0,
+        sortedTabs.find((tab) => tab.id === Number(draggableId.split('-')[1])) as ITab,
+      );
 
+      const newTabOrder = newSortedTabs.map((tab) => tab.id);
       const prevIndex = newTabOrder.indexOf(Number(draggableId.split('-')[1])) - 1;
       const requestData = {
         planId: plan.id,
@@ -219,11 +192,8 @@ function Plan() {
         newPrevId: prevIndex === -1 ? null : newTabOrder[prevIndex],
       };
 
-      // setSortedTabs(newTabOrder);
-
-      console.log(prevIndex, requestData);
       dragTabMutate(requestData);
-      console.log(dragTabMutate);
+      setSortedTabs(newSortedTabs);
     }
 
     if (sourceType === 'task') {
@@ -234,7 +204,6 @@ function Plan() {
       const start = tasks[+Number(source.droppableId.split('-')[1])];
       const finish = tasks[+Number(destination.droppableId.split('-')[1])] || [];
       const updatedTask = start[source.index];
-      // console.log(start, finish, updatedTask);
 
       start.splice(source.index, 1);
       if (start === finish) {
@@ -346,7 +315,6 @@ function Plan() {
             </div>
           </UtilContainer>
         </TopContainer>
-        {/* <TabGroup data-droppable-id={1} className="droppable"> */}
         <TabContainer>
           <DragDropContext onDragEnd={onDragEnd as OnDragEndResponder}>
             <Droppable direction="horizontal" droppableId="tab" type="tab">

--- a/src/pages/Plan/styles.ts
+++ b/src/pages/Plan/styles.ts
@@ -99,19 +99,15 @@ export const UtilContainer = styled.div`
   }
 `;
 
-export const TabGroup = styled.ul`
-  /* width: calc(100vw - 22rem);
-  height: calc(100% - 4rem); */
-  display: flex;
-  gap: 1.5rem;
-`;
-
 export const TabContainer = styled.div`
   width: calc(100vw - 22rem);
   height: calc(100% - 4rem);
   display: flex;
-  /* gap: 1.5rem;
-  overflow-x: auto; */
+`;
+
+export const TabGroup = styled.ul`
+  display: flex;
+  gap: 1.5rem;
 `;
 
 export const AddTabButton = styled.button`

--- a/src/pages/Plan/styles.ts
+++ b/src/pages/Plan/styles.ts
@@ -100,15 +100,18 @@ export const UtilContainer = styled.div`
 `;
 
 export const TabGroup = styled.ul`
-  width: calc(100vw - 22rem);
-  height: calc(100% - 4rem);
+  /* width: calc(100vw - 22rem);
+  height: calc(100% - 4rem); */
   display: flex;
+  gap: 1.5rem;
 `;
 
 export const TabContainer = styled.div`
+  width: calc(100vw - 22rem);
+  height: calc(100% - 4rem);
   display: flex;
-  gap: 1.5rem;
-  overflow-x: auto;
+  /* gap: 1.5rem;
+  overflow-x: auto; */
 `;
 
 export const AddTabButton = styled.button`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,7 +47,7 @@ export interface IMember {
 export interface ITab {
   id: number;
   title: string;
-  tasks?: ITask[];
+  taskOrde?: number[];
 }
 
 export interface IPlanTitle {


### PR DESCRIPTION
📌 Description
- 태스크뿐만 아니라 탭도 beautiful-dnd로 전환했습니다.
  - 탭 dnd인지 태스크 dnd인지에 따라 droppableId, draggableId를 tab-7, task-30 이런 식으로 변경했습니다.
  - onDragEnd 함수에서 droppableId의 앞 부분이 tab, task 인지에 따라 dnd 로직을 수행하도록 만들었습니다.

⚠️ 주의사항
- 탭을 드래그 했다가 드롭할때 해당 탭과 놓이는 위치에 있는 탭의 gap이 사라져서 잠깐 붙었다가 떨어집니다. 
 - css 문제인데 추후에 수정하겠습니다. 혹시 준영님이 보시고 어떤 문제인지 아시면 알려주시면 감사하겠습니다. 

close #127