### PR TITLE
[#131] 메인 페이지 api 연결 및 planId 리팩토링

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -57,8 +57,8 @@ export const getPlanInfo = async (planId: number) => {
 };
 
 export const getAllPlanTitles = async () => {
-  const response = await api.get('/api/plans/all');
-  return response;
+  const { data } = await api.get('/api/plans/all');
+  return data;
 };
 
 export const createPlan = async (requestBody: {

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -44,6 +44,12 @@ export const requestNewToken = async () => {
   return data;
 };
 
+// Main
+export const getMain = async () => {
+  const { data } = await api.get(`/api/plans/main`);
+  return data;
+};
+
 /* Plan */
 export const getPlanInfo = async (planId: number) => {
   const { data } = await api.get(`/api/plans/${planId}`);

--- a/src/components/BriefPlan/index.tsx
+++ b/src/components/BriefPlan/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { BiInfinite } from 'react-icons/bi';
-import { ITaskInfo } from 'types';
 
 import {
   Wrapper,
@@ -16,58 +15,39 @@ import {
 } from './styles';
 
 import { ReactComponent as NoData } from '@assets/images/noData.svg';
-import { hashStringToColor, parseTasksByStatus } from '@utils';
+import { ITabs, ITask } from '@pages/Main';
+import { hashStringToColor } from '@utils';
 
 interface Props {
-  planName: string;
   planId: number;
-  tabName: string[];
-  tasks: ITaskInfo[];
+  planTitle: string;
+  tabOrder: number[];
+  tabs: ITabs[];
 }
 
-function BriefPlan({ planName, planId, tabName, tasks }: Props) {
-  const changeDateToDday = (deadline: string) => {
-    // TODO: 이후 서버와 통신할 때 전달 받는 날짜 형식이 수정된다면 함께 수정 필요
-    const splitDeadline = deadline.split('-');
-    const deadlineYear = parseInt(splitDeadline[0], 10);
-    const deadlineMonth = parseInt(splitDeadline[1], 10) - 1; // 월은 0부터 시작하므로 1을 빼줍니다.
-    const deadlineDay = parseInt(splitDeadline[2], 10);
-    const targetDate = new Date(deadlineYear, deadlineMonth, deadlineDay);
-
-    const currentDate = new Date();
-    const timeDiff = targetDate.getTime() - currentDate.getTime();
-    const dDay = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
-
-    if (dDay === 0) return 'D-Day';
-    if (dDay > 0) return `D-${dDay}`;
-    return `D+${Math.abs(dDay)}`;
-  };
-
+function BriefPlan({ planId, planTitle, tabOrder, tabs }: Props) {
   return (
     <Wrapper>
       <PlanName to={`/plan/${planId}`}>
-        <p>{planName}</p>
+        <p>{planTitle}</p>
       </PlanName>
       <TaskWrapper>
-        {tasks.length === 0 ? (
+        {tabOrder.length === 0 ? (
           <EmptyTaskFrame>
             <p>할일을 추가해주세요</p>
             <NoData />
           </EmptyTaskFrame>
         ) : (
-          parseTasksByStatus(tasks, tabName).map((taskList, idx) => (
-            <TaskContainer key={`${planId}-${tabName[idx]}`}>
-              <TaskStatusName>{`${tabName[idx]}(${taskList.length})`}</TaskStatusName>
+          tabs.map((tab) => (
+            <TaskContainer key={`${planId}-${tab.tabId}`}>
+              <TaskStatusName>{`${tab.title} (${tab.taskList.length})`}</TaskStatusName>
               <TaskFrame>
-                {taskList.map((task: ITaskInfo) => (
-                  <Task key={task.id}>
-                    <p>{task.name}</p>
-                    <TaskDeadline color={hashStringToColor(changeDateToDday(task.deadline))}>
-                      {task.deadline.length > 0 ? (
-                        <span>{changeDateToDday(task.deadline)}</span>
-                      ) : (
-                        <BiInfinite size="20" />
-                      )}
+                {/* TODO, PROGRESS만 보여줄지 고민 */}
+                {tab.taskList.map((task: ITask) => (
+                  <Task key={task.taskId}>
+                    <p>{task.title}</p>
+                    <TaskDeadline color={hashStringToColor(task.dday.toString())}>
+                      {task.dday > 0 ? <span>{task.dday}</span> : <BiInfinite size="20" />}
                     </TaskDeadline>
                   </Task>
                 ))}

--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -1,0 +1,30 @@
+import { getMain } from '@apis';
+import { IPlan } from '@pages/Main';
+import { useQuery } from '@tanstack/react-query';
+
+interface UseMain {
+  main: IPlan[];
+}
+
+export function useMain(): UseMain {
+  const commonOptions = {
+    staleTime: 300000,
+    cacheTime: 300000, // 5 minutes
+  };
+
+  const fallback: IPlan[] = [];
+
+  const { data: main = fallback } = useQuery<IPlan[], Error>({
+    queryKey: ['main'],
+    queryFn: getMain,
+    ...commonOptions,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    refetchInterval: 60000, // 60 seconds
+  });
+
+  return {
+    main,
+  };
+}

--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -8,7 +8,7 @@ interface UseMain {
 
 export function useMain(): UseMain {
   const commonOptions = {
-    staleTime: 300000,
+    staleTime: 0,
     cacheTime: 300000, // 5 minutes
   };
 

--- a/src/hooks/usePlanTitle.ts
+++ b/src/hooks/usePlanTitle.ts
@@ -1,0 +1,31 @@
+import { IPlanTitle } from 'types';
+
+import { getAllPlanTitles } from '@apis';
+import { useQuery } from '@tanstack/react-query';
+
+interface UsePlanTitle {
+  allPlanTitles: IPlanTitle[];
+}
+
+export function usePlanTitle(): UsePlanTitle {
+  const commonOptions = {
+    staleTime: 0,
+    cacheTime: 300000, // 5 minutes
+  };
+
+  const fallback: IPlanTitle[] = [];
+
+  const { data: allPlanTitles = fallback } = useQuery<IPlanTitle[], Error>({
+    queryKey: ['allPlanTitles'],
+    queryFn: getAllPlanTitles,
+    ...commonOptions,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    refetchInterval: 60000, // 60 seconds
+  });
+
+  return {
+    allPlanTitles,
+  };
+}

--- a/src/hooks/useUpdatePlan.ts
+++ b/src/hooks/useUpdatePlan.ts
@@ -1,0 +1,81 @@
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+
+import useToast from './useToast';
+
+import { api } from '@apis';
+import { currentPlanIdState } from '@recoil/atoms';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface PlanInfo {
+  requestBody: { title: string; intro: string; invitedEmails: string[]; isPublic: boolean };
+}
+
+interface UpdatePlanInfo {
+  planId: number;
+  requestBody: {
+    isPublic: boolean;
+    ownerId: number | undefined;
+    invitedEmails: string[];
+    kickingMemberIds: number[];
+    title: string;
+    intro: string;
+  };
+}
+
+interface DeleteInfo {
+  planId: number;
+}
+
+export const createNewPlan = async (params: PlanInfo) => {
+  const { data } = await api.post('/api/plans', params.requestBody);
+  return data;
+};
+
+export const updatePlanInfo = async (params: UpdatePlanInfo) => {
+  await api.put(`/api/plans/update/${params.planId}`, params.requestBody);
+};
+
+export const deletePlan = async (params: { planId: number }) => {
+  await api.delete(`/api/plans/${params.planId}`);
+};
+
+export function useUpdatePlan(planId: number | null) {
+  const navigate = useNavigate();
+  const setCurrentPlanId = useSetRecoilState(currentPlanIdState);
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const { mutate: createPlanMutate } = useMutation({
+    mutationFn: async (data: PlanInfo) => {
+      const response = await createNewPlan(data);
+      return response;
+    },
+
+    onSuccess: (result) => {
+      showToast('플랜이 추가되었습니다.', { type: 'success' });
+      setCurrentPlanId(result.id);
+      navigate(`/plan/${result.id}`);
+    },
+  });
+
+  const { mutate: updatePlanInfoMutate } = useMutation({
+    mutationFn: (data: UpdatePlanInfo) => updatePlanInfo(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('플랜 정보가 수정되었습니다.', { type: 'success' });
+    },
+  });
+
+  const { mutate: deletePlanMutate } = useMutation({
+    mutationFn: (data: DeleteInfo) => deletePlan(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      showToast('플랜이 삭제되었습니다.', { type: 'success' });
+    },
+  });
+
+  return { createPlanMutate, updatePlanInfoMutate, deletePlanMutate };
+}

--- a/src/hooks/useUpdatePlan.ts
+++ b/src/hooks/useUpdatePlan.ts
@@ -54,6 +54,7 @@ export function useUpdatePlan(planId: number | null) {
 
     onSuccess: (result) => {
       showToast('플랜이 추가되었습니다.', { type: 'success' });
+      queryClient.invalidateQueries({ queryKey: ['allPlanTitles'] });
       setCurrentPlanId(result.id);
       navigate(`/plan/${result.id}`);
     },
@@ -72,7 +73,7 @@ export function useUpdatePlan(planId: number | null) {
     mutationFn: (data: DeleteInfo) => deletePlan(data),
 
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+      queryClient.invalidateQueries({ queryKey: ['allPlanTitles'] });
       showToast('플랜이 삭제되었습니다.', { type: 'success' });
     },
   });

--- a/src/pages/CreatePlan/index.tsx
+++ b/src/pages/CreatePlan/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState, useRecoilState } from 'recoil';
+// import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
 import {
   Wrapper,
@@ -13,12 +13,13 @@ import {
   Button,
 } from './styles';
 
-import { createPlan } from '@apis';
+// import { createPlan } from '@apis';
 import boardIllust from '@assets/images/boardIllust.svg';
 import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
 import ToggleSwitch from '@components/ToggleSwitch';
-import { currentPlanIdState, accessTokenState } from '@recoil/atoms';
+import { useUpdatePlan } from '@hooks/useUpdatePlan';
+import { accessTokenState } from '@recoil/atoms';
 import { authenticate } from '@utils/auth';
 
 type PlanInfo = {
@@ -34,8 +35,9 @@ function CreatePlan() {
   });
   const [invitedEmails, setInvitedEmails] = useState<string[]>([]);
   const [isPublic, setIsPublic] = useState<boolean>(false);
-  const navigate = useNavigate();
-  const setCurrentPlanId = useSetRecoilState(currentPlanIdState);
+  // const navigate = useNavigate();
+  // const setCurrentPlanId = useSetRecoilState(currentPlanIdState);
+  const { createPlanMutate } = useUpdatePlan(null);
 
   const changePlanInfo = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -79,26 +81,7 @@ function CreatePlan() {
       isPublic,
     };
 
-    try {
-      const { status, data } = await createPlan(requestBody);
-      if (status === 201) {
-        // setCurrentPlanId를 변경하지 않고 plan/data.id로 가는경우
-        // 경로에 있는 data.id를 사용해서 데이터를 불러오지 않고
-        // recoil에 이미 저장되어 있는 id의 플랜 정보를 불러온다.
-        // 즉 플랜이 없다가 만들어진 경우
-        // 이전 recoil에 currentPlanId가 없기 때문에
-        // plan 페이지로 넘어갔을 떄 데이터를 받아오지 않는다.
-        setCurrentPlanId(data.id);
-        navigate(`/plan/${data.id}`);
-      } else {
-        throw new Error();
-      }
-    } catch (error) {
-      // eslint-disable-next-line
-      alert('플랜이 정상적으로 만들어지지 않았어요 :(');
-    }
-
-    return requestBody;
+    createPlanMutate({ requestBody });
   };
 
   useEffect(() => {

--- a/src/pages/CreatePlan/index.tsx
+++ b/src/pages/CreatePlan/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 
-// import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 import {
@@ -13,7 +12,6 @@ import {
   Button,
 } from './styles';
 
-// import { createPlan } from '@apis';
 import boardIllust from '@assets/images/boardIllust.svg';
 import InputField from '@components/InputField';
 import ManageTeam from '@components/ManageTeam';
@@ -35,8 +33,6 @@ function CreatePlan() {
   });
   const [invitedEmails, setInvitedEmails] = useState<string[]>([]);
   const [isPublic, setIsPublic] = useState<boolean>(false);
-  // const navigate = useNavigate();
-  // const setCurrentPlanId = useSetRecoilState(currentPlanIdState);
   const { createPlanMutate } = useUpdatePlan(null);
 
   const changePlanInfo = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,78 +1,42 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useNavigate } from 'react-router-dom';
-import { ITaskInfo } from 'types';
 
 import { Wrapper, EmptyTeamPlanFrame } from './styles';
 
 import { ReactComponent as NoPlan } from '@assets/images/noPlan.svg';
 import BriefPlan from '@components/BriefPlan';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
+import { useMain } from '@hooks/useMain';
 
-/* 테스트용 데이터 */
-interface IDummyPlan {
-  name: string;
-  id: number;
-  tasks: ITaskInfo[];
+export interface ITask {
+  taskId: number;
+  title: string;
+  dday: number;
 }
-const tabName = ['To do', 'In Progress', 'Done'];
-const plansDummy: IDummyPlan[] = [
-  {
-    name: 'My plan',
-    id: 1,
-    tasks: [
-      { name: 'task1', id: '1', status: 0, labels: ['label1', 'label2'], deadline: '2023-10-10' },
-      { name: 'task2', id: '2', status: 0, labels: ['label1'], deadline: '2023-10-11' },
-      { name: 'task3', id: '3', status: 0, labels: ['label2'], deadline: '' },
-      { name: 'task4', id: '4', status: 0, labels: ['label1', 'label2'], deadline: '' },
-      { name: 'task5', id: '5', status: 1, labels: ['label1', 'label2'], deadline: '2023-10-10' },
-      { name: 'task6', id: '6', status: 1, labels: ['label1'], deadline: '2023-10-11' },
-      { name: 'task7', id: '7', status: 1, labels: ['label2'], deadline: '' },
-      { name: 'task8', id: '8', status: 1, labels: ['label1', 'label2'], deadline: '' },
-    ],
-  },
-  {
-    name: 'Team Plan1',
-    id: 2,
-    tasks: [
-      { name: 'task1', id: '1', status: 0, labels: ['label1', 'label2'], deadline: '2023-10-10' },
-      { name: 'task2', id: '2', status: 0, labels: ['label1'], deadline: '2023-10-11' },
-      { name: 'task3', id: '3', status: 0, labels: ['label2'], deadline: '' },
-      { name: 'task4', id: '4', status: 0, labels: ['label1', 'label2'], deadline: '' },
-      { name: 'task5', id: '5', status: 1, labels: ['label1', 'label2'], deadline: '2023-10-10' },
-      { name: 'task6', id: '6', status: 1, labels: ['label1'], deadline: '2023-10-11' },
-      { name: 'task7', id: '7', status: 1, labels: ['label2'], deadline: '' },
-      { name: 'task8', id: '8', status: 1, labels: ['label1', 'label2'], deadline: '' },
-    ],
-  },
-  {
-    name: 'Team Plan2',
-    id: 3,
-    tasks: [
-      { name: 'task1', id: '1', status: 0, labels: ['label1', 'label2'], deadline: '2023-10-10' },
-      { name: 'task2', id: '2', status: 0, labels: ['label1'], deadline: '2023-10-11' },
-      { name: 'task3', id: '3', status: 0, labels: ['label2'], deadline: '' },
-      { name: 'task4', id: '4', status: 0, labels: ['label1', 'label2'], deadline: '' },
-      { name: 'task5', id: '5', status: 1, labels: ['label1', 'label2'], deadline: '2023-10-10' },
-      { name: 'task6', id: '6', status: 1, labels: ['label1'], deadline: '2023-10-11' },
-      { name: 'task7', id: '7', status: 1, labels: ['label2'], deadline: '' },
-      { name: 'task8', id: '8', status: 1, labels: ['label1', 'label2'], deadline: '' },
-    ],
-  },
-  {
-    name: 'Team Plan3',
-    id: 4,
-    tasks: [],
-  },
-];
+
+export interface ITabs {
+  tabId: number;
+  title: string;
+  taskList: ITask[];
+  taskOrder: number[];
+}
+
+export interface IPlan {
+  planId: number;
+  title: string;
+  tabOrder: number[];
+  tabs: ITabs[];
+}
 
 function Main() {
-  const [plans] = useState<IDummyPlan[]>(plansDummy);
+  const { main } = useMain();
+
   const navigate = useNavigate();
 
   return (
     <Wrapper>
-      {plans.length === 0 ? (
+      {main.length === 0 ? (
         <EmptyTeamPlanFrame>
           <div>
             <p>내가 속한 플랜이 없어요 😵</p>
@@ -88,8 +52,16 @@ function Main() {
           </div>
         </EmptyTeamPlanFrame>
       ) : (
-        plans.map((plan) => {
-          return <BriefPlan key={plan.id} planName={plan.name} planId={plan.id} tabName={tabName} tasks={plan.tasks} />;
+        main.map((plan) => {
+          return (
+            <BriefPlan
+              key={plan.planId}
+              planId={plan.planId}
+              planTitle={plan.title}
+              tabOrder={plan.tabOrder}
+              tabs={plan.tabs}
+            />
+          );
         })
       )}
     </Wrapper>

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -6,7 +6,7 @@ import { Droppable, DragDropContext, OnDragEndResponder } from 'react-beautiful-
 import { CiSettings } from 'react-icons/ci';
 import { IoIosStarOutline } from 'react-icons/io';
 import { SlPlus } from 'react-icons/sl';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { ITask, ITab } from 'types';
 
@@ -65,7 +65,6 @@ function Plan() {
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
   const [sortedTabs, setSortedTabs] = useState<{ id: number; title: string; taskOrder?: number[] }[]>([]);
   const [tasks, setTasks] = useState<Record<number, ITask[]>>({});
-  const { planId } = useParams();
   const [currentPlanId, setCurrentPlanId] = useRecoilState(currentPlanIdState);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [newTabTitle, setNewTabTitle] = useState<string>('');
@@ -73,12 +72,8 @@ function Plan() {
 
   const [selectedLabels, setSelectedLabel] = useState<number[]>([]);
   const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
-  // const [planTitles, setPlanTitles] = useRecoilState(planTitlesState);
   const { plan, tasksByTab } = usePlan(currentPlanId, selectedLabels, selectedMembers);
-  const { createTabMutate, deleteTabMutate, dragTabMutate } = useUpdateTab(
-    // TODO: planId 리팩토링 필요
-    Number(plan.id),
-  );
+  const { createTabMutate, deleteTabMutate, dragTabMutate } = useUpdateTab(Number(plan.id));
 
   const queryClient = useQueryClient();
   const { allPlanTitles } = usePlanTitle();
@@ -118,10 +113,10 @@ function Plan() {
   }, [accessToken, setAccessToken]);
 
   useEffect(() => {
-    if (planId === undefined && allPlanTitles.length > 0) {
+    if (currentPlanId === -1 && allPlanTitles.length > 0) {
       setCurrentPlanId(allPlanTitles[0].id);
     }
-  }, [planId, allPlanTitles]);
+  }, [allPlanTitles]);
 
   const handleStartAddingTab = () => {
     setIsAddingTab(true);

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -32,6 +32,7 @@ import Modal from '@components/Modal';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import { Tab, TasksContainer } from '@components/Tab';
 import { usePlan } from '@hooks/usePlan';
+// import { usePlanTitle } from '@hooks/usePlanTitle';
 import { useUpdateTab } from '@hooks/useUpdateTab';
 import { currentPlanIdState, planTitlesState, accessTokenState } from '@recoil/atoms';
 import { authenticate } from '@utils/auth';
@@ -77,6 +78,8 @@ function Plan() {
     // TODO: planId 리팩토링 필요
     Number(plan.id),
   );
+  // const { allPlanTitles } = usePlanTitle();
+  // console.log(allPlanTitles);
 
   const navigate = useNavigate();
 
@@ -95,7 +98,7 @@ function Plan() {
   useEffect(() => {
     const getPlanTitles = async () => {
       try {
-        const { data } = await getAllPlanTitles();
+        const data = await getAllPlanTitles();
         setPlanTitles(data);
         if (currentPlanId === -1 && data.length > 0) setCurrentPlanId(data[0].id);
       } catch (error) {


### PR DESCRIPTION
📌 Description
- 메인 페이지 api 연결
- plan 생성, 정보변경, 삭제 요청 react-query로 변경
- planId를 리팩토링

⚠️ 주의사항
- 메인 페이지에서 각 플랜 별로 Todo, Progress탭만 보여주기가 어렵습니다. Todo탭과 달리 Progress탭은 이름이 변경돼서 알아볼 방법이 없더라구요. 일단은 모든 탭을 보여주고 있습니다.
- planId를 리팩토링 하다보니 recoil로 planTitles를 관리할 필요가 없는 것 같아서 플랜 페이지에서는 지웠습니다. 플랜 삭제 모달에서만 해결하면 planTitlesState를 없앨 생각입니다. 
- react-query 관련 중복되는 코드(api, queryClient 옵션 등)는 추후에 제거하겠습니다.

close #131