### PR TITLE
[#138] 플랜 타이틀 프리페치를 통해 planId 리팩토링, 태스크 dnd 버그 수정

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -140,6 +140,10 @@ export interface DragInfo {
   targetId: number;
   newPrevId: number | null;
 }
+export const getTask = async (taskId: number) => {
+  const { data } = await api.get(`/api/tasks/${taskId}`);
+  return data;
+};
 
 export const createNewTask = async (params: TaskInfo): Promise<void> => {
   await api.post('/api/tasks', params);

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
 import { AiOutlineHome } from 'react-icons/ai';
-import { ImCompass2 } from 'react-icons/im';
 import { LuCalendarPlus, LuCalendarDays } from 'react-icons/lu';
 import { useLocation } from 'react-router-dom';
 
@@ -15,13 +14,9 @@ const navMenu = [
   { id: 1, value: 'main', icon: AiOutlineHome, link: '/main' },
   { id: 2, value: 'create-plan', icon: LuCalendarPlus, link: '/create-plan' },
   { id: 3, value: 'plan', icon: LuCalendarDays, link: '/plan' },
-  { id: 4, value: 'explore', icon: ImCompass2, link: '/#' },
 ];
 
-const dropdownOptions = [
-  { id: 1, label: '프로필 변경', value: 'profile' },
-  { id: 2, label: '로그아웃', value: 'logout' },
-];
+const dropdownOptions = [{ id: 1, label: '로그아웃', value: 'logout' }];
 
 function Header() {
   const [selectedMenu, setSelectedMenu] = useState<string>('main');

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -88,6 +88,7 @@ function TabHeader({ id, initialTitle, onDeleteTab }: ITabHeaderProps) {
       {isEditing ? (
         <EditableTitle
           type="text"
+          required
           ref={inputRef}
           value={title}
           onChange={(e) => setTitle(e.target.value)}

--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -56,27 +56,28 @@ export function usePlan(planId: number, selectedLabels: number[], selectedMember
       setMembers(members);
       setLabels(labels);
     }
-  }, [plan, setMembers, setLabels]);
+  }, [plan]);
 
   const tasksByTab = useMemo(() => {
     const result: Record<number, ITask[]> = {};
 
     if (filteredPlan) {
-      filteredPlan.tasks.forEach((task) => {
-        const { tabId } = task;
-        result[tabId] = result[tabId] || [];
-        result[tabId].push(task);
+      filteredPlan.tabs.forEach((tab) => {
+        const { id } = tab;
+        result[id] = [];
+        tab.taskOrder!.forEach((order) => {
+          const foundTask = filteredPlan.tasks.find((item) => item.id === order);
+          if (foundTask) {
+            result[id].push(foundTask);
+          }
+        });
       });
     }
-
     return result;
   }, [filteredPlan]);
 
-  // TODO: tasksByTab이 2번 실행돼서 태스크 순서 변경이 안됨
-  // console.log(tasksByTab);
-
   return {
-    plan: filteredPlan,
+    plan,
     tasksByTab,
   };
 }

--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -16,9 +16,8 @@ export function usePlan(planId: number, selectedLabels: number[], selectedMember
   const setMembers = useSetRecoilState(membersState);
   const setLabels = useSetRecoilState(labelsState);
 
-  // TODO: 폴백 데이터에 id가 0이어도 되나?
   const fallback = {
-    id: 0,
+    id: -1,
     title: '',
     description: '',
     public: false,

--- a/src/hooks/usePlanTitle.ts
+++ b/src/hooks/usePlanTitle.ts
@@ -1,9 +1,14 @@
+import { useEffect } from 'react';
+
 import { useSetRecoilState } from 'recoil';
 import { IPlanTitle } from 'types';
 
+import { currentPlanIdState } from '../recoil/atoms';
+
 import { getAllPlanTitles } from '@apis';
-import { currentPlanIdState } from '@recoil/atoms';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryClient } from '@components/react-query/queryClient';
+import { useQuery } from '@tanstack/react-query';
+import { prefetchAndSetPlanId } from '@utils';
 
 interface UsePlanTitle {
   allPlanTitles: IPlanTitle[];
@@ -24,12 +29,8 @@ export function usePlanTitle(): UsePlanTitle {
 
 export function usePrefetchPlanTitles(): void {
   const setCurrentPlanId = useSetRecoilState(currentPlanIdState);
-  const queryClient = useQueryClient();
-  queryClient.prefetchQuery({ queryKey: ['allPlanTitles'], queryFn: getAllPlanTitles });
 
-  const { data: cachedPlanTitles } = useQuery<IPlanTitle[]>({ queryKey: ['allPlanTitles'] });
-
-  if (cachedPlanTitles && cachedPlanTitles.length !== 0) {
-    setCurrentPlanId(cachedPlanTitles[0].id);
-  }
+  useEffect(() => {
+    prefetchAndSetPlanId(setCurrentPlanId);
+  }, [queryClient, setCurrentPlanId]);
 }

--- a/src/hooks/usePlanTitle.ts
+++ b/src/hooks/usePlanTitle.ts
@@ -1,7 +1,9 @@
+import { useSetRecoilState } from 'recoil';
 import { IPlanTitle } from 'types';
 
 import { getAllPlanTitles } from '@apis';
-import { useQuery } from '@tanstack/react-query';
+import { currentPlanIdState } from '@recoil/atoms';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 interface UsePlanTitle {
   allPlanTitles: IPlanTitle[];
@@ -18,4 +20,16 @@ export function usePlanTitle(): UsePlanTitle {
   return {
     allPlanTitles,
   };
+}
+
+export function usePrefetchPlanTitles(): void {
+  const setCurrentPlanId = useSetRecoilState(currentPlanIdState);
+  const queryClient = useQueryClient();
+  queryClient.prefetchQuery({ queryKey: ['allPlanTitles'], queryFn: getAllPlanTitles });
+
+  const { data: cachedPlanTitles } = useQuery<IPlanTitle[]>({ queryKey: ['allPlanTitles'] });
+
+  if (cachedPlanTitles && cachedPlanTitles.length !== 0) {
+    setCurrentPlanId(cachedPlanTitles[0].id);
+  }
 }

--- a/src/hooks/useTask.ts
+++ b/src/hooks/useTask.ts
@@ -1,0 +1,30 @@
+import { ITask } from 'types';
+
+import { getTask } from '@apis';
+import { useQuery } from '@tanstack/react-query';
+
+interface UseTask {
+  task: ITask;
+}
+
+export function useTask(task: ITask): UseTask {
+  const fallback = {
+    id: task.id,
+    title: task.title,
+    tabId: task.tabId,
+    labels: task.labels,
+    assigneeId: task.assigneeId,
+    startDate: task.startDate,
+    endDate: task.endDate,
+    description: task.description,
+  };
+
+  const { data: fullTask = fallback } = useQuery<ITask, Error>({
+    queryKey: ['task', task.id],
+    queryFn: () => getTask(task.id),
+  });
+
+  return {
+    task: fullTask,
+  };
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -11,13 +11,13 @@ const useToast = () => {
     toast(message, {
       type,
       position: 'top-right',
-      autoClose: 1000,
+      autoClose: 200,
       hideProgressBar: false,
       closeOnClick: true,
       pauseOnHover: true,
       draggable: true,
       progress: undefined,
-      theme: 'light',
+      theme: 'colored',
     });
   };
 

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -6,9 +6,11 @@ import { Wrapper, EmptyTeamPlanFrame } from './styles';
 
 import { ReactComponent as NoPlan } from '@assets/images/noPlan.svg';
 import BriefPlan from '@components/BriefPlan';
+import LoadingSpinner from '@components/Loading';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import { useMain } from '@hooks/useMain';
 import { usePrefetchPlanTitles } from '@hooks/usePlanTitle';
+import { useIsFetching } from '@tanstack/react-query';
 
 export interface ITask {
   taskId: number;
@@ -34,10 +36,12 @@ function Main() {
   usePrefetchPlanTitles();
   const { main } = useMain();
   const navigate = useNavigate();
+  const isFetching = useIsFetching();
 
   return (
     <Wrapper>
-      {main.length === 0 ? (
+      <LoadingSpinner />
+      {!isFetching && main.length === 0 ? (
         <EmptyTeamPlanFrame>
           <div>
             <p>내가 속한 플랜이 없어요 😵</p>

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as NoPlan } from '@assets/images/noPlan.svg';
 import BriefPlan from '@components/BriefPlan';
 import { ModalButton } from '@components/Modal/CommonModalStyles';
 import { useMain } from '@hooks/useMain';
+import { usePrefetchPlanTitles } from '@hooks/usePlanTitle';
 
 export interface ITask {
   taskId: number;
@@ -30,8 +31,8 @@ export interface IPlan {
 }
 
 function Main() {
+  usePrefetchPlanTitles();
   const { main } = useMain();
-
   const navigate = useNavigate();
 
   return (

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -73,17 +73,6 @@ function Plan() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // console.log(currentPlanId, allPlanTitles);
-    // 플랜 삭제 후 남은 플랜이 없을 때 currentPlanId를 -1로 set함
-    if (allPlanTitles.length === 0) setCurrentPlanId(-1);
-    // 로그인 후 바로 들어왔을 때 속한 플랜은 있으나 currentPlanId는 -1인 경우
-    // allPlanTitles[0]로 setCurrentPlanId 해줌
-    if (currentPlanId === -1 && allPlanTitles.length !== 0) {
-      setCurrentPlanId(allPlanTitles[0].id);
-    }
-  }, [allPlanTitles]);
-
-  useEffect(() => {
     setTasks(tasksByTab);
     const tabById: Record<number, ITab> = {};
     plan.tabs.forEach((tab) => {

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -71,10 +71,10 @@ function Plan() {
   useEffect(() => {
     setTasks(tasksByTab);
     const tabById: Record<number, ITab> = {};
-    plan.tabs.forEach((tab) => {
+    plan?.tabs.forEach((tab) => {
       tabById[tab.id] = tab;
     });
-    const newSortedTabs = plan.tabOrder.map((tabId) => {
+    const newSortedTabs = plan?.tabOrder.map((tabId) => {
       return tabById[tabId];
     });
     setSortedTabs(newSortedTabs);
@@ -327,7 +327,7 @@ function Plan() {
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...provided.droppableProps}
               >
-                {sortedTabs.map((item, index) => {
+                {sortedTabs?.map((item, index) => {
                   return (
                     <Tab
                       id={item.id}
@@ -337,7 +337,6 @@ function Plan() {
                       onDeleteTab={() => handleDeleteTab(item.id)}
                       tasks={tasks[item.id] || []}
                       onAddTask={setTasks}
-                      // onRemoveTask={handleDeleteTask}
                       onEditTask={handleEditTask}
                     />
                   );
@@ -351,6 +350,7 @@ function Plan() {
                       onChange={(e) => setNewTabTitle(e.target.value)}
                       onBlur={handleAddTab}
                       onKeyDown={handleInputKeyDown}
+                      required
                     />
                     <TasksContainer />
                   </TabWrapper>

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -244,7 +244,7 @@ function Plan() {
     });
   };
 
-  if (allPlanTitles.length === 0 || (currentPlanId === -1 && allPlanTitles.length === 0)) {
+  if (allPlanTitles.length === 0) {
     return (
       <EmptyPlanContainer>
         <EmptyPlanContents>

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -62,8 +62,8 @@ function Plan() {
   const [selectedLabels, setSelectedLabel] = useState<number[]>([]);
   const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
   const { plan, tasksByTab } = usePlan(currentPlanId, selectedLabels, selectedMembers);
-  const { createTabMutate, deleteTabMutate, dragTabMutate } = useUpdateTab(Number(plan.id));
-  const { dragTaskMutate } = useUpdateTask(Number(plan.id));
+  const { createTabMutate, deleteTabMutate, dragTabMutate } = useUpdateTab(currentPlanId);
+  const { dragTaskMutate } = useUpdateTask(currentPlanId);
   const { allPlanTitles } = usePlanTitle();
 
   const navigate = useNavigate();
@@ -194,7 +194,9 @@ function Plan() {
         });
         return;
       }
-      updatedTask.tabId = +Number(destination.droppableId.split('-')[1]);
+      // TODO: tabId가 readonly로 선언되었다는데 어디인지 찾아야함
+      const notread = { ...updatedTask };
+      notread.tabId = +Number(destination.droppableId.split('-')[1]);
       finish.splice(destination.index, 0, updatedTask);
       // TODO: order가 추가될 수 있음
       const newStart = [...start];
@@ -217,10 +219,6 @@ function Plan() {
         targetId: Number(draggableId.split('-')[1]),
         newPrevId: newFinish[prevIndex].id,
       };
-
-      // TODO: 태스크 순서 변경이 받아온 데이터에서는 되있으나 화면상으로 안 됨
-      // console.log(requestData);
-
       dragTaskMutate(requestData);
     }
   };

--- a/src/pages/Plan/index.tsx
+++ b/src/pages/Plan/index.tsx
@@ -79,7 +79,7 @@ function Plan() {
       return tabById[tabId];
     });
     setSortedTabs(newSortedTabs);
-  }, [plan]);
+  }, [plan, selectedLabels, selectedMembers]);
 
   useEffect(() => {
     const checkAccessTokenAndGetPlanTitles = async () => {

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -94,7 +94,6 @@ function Setting() {
       deletePlanMutate({ planId: state.id });
       const newPlanId = planTitles.length > 1 ? planTitles.filter((item) => item.id !== state.id)[0].id : -1;
       setCurrentPlanId(newPlanId);
-      // TODO: 플랜 삭제 후 플랜이 없을 때 버그 수정 필요함
       navigate('/plan');
     };
     setModalData({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,7 +47,7 @@ export interface IMember {
 export interface ITab {
   id: number;
   title: string;
-  taskOrde?: number[];
+  taskOrder?: number[];
 }
 
 export interface IPlanTitle {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,7 @@
-import { ITaskInfo } from 'types';
+import { ITaskInfo, IPlanTitle } from 'types';
+
+import { getAllPlanTitles } from '@apis';
+import { queryClient } from '@components/react-query/queryClient';
 
 export const parseTasksByStatus = (tasks: ITaskInfo[], statusName: string[]) => {
   const parsedTasks = [];
@@ -36,4 +39,18 @@ export const hashStringToColor = (id: string) => {
   const lightness = 50 + ((hash >> 1) % 20); // eslint-disable-line no-bitwise
 
   return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+};
+
+// TODO: 어느 파일에 둬야할지 고민
+export const prefetchAndSetPlanId = async (
+  setCurrentPlanId: (value: number | ((currVal: number) => number)) => void,
+) => {
+  // 프리패치
+  await queryClient.prefetchQuery({ queryKey: ['allPlanTitles'], queryFn: getAllPlanTitles });
+
+  // 프리패치가 완료된 후에 데이터를 가져와서 처리
+  const allPlanTitles = queryClient.getQueryData<IPlanTitle[]>(['allPlanTitles']);
+  if (allPlanTitles && allPlanTitles.length > 0) {
+    setCurrentPlanId(allPlanTitles[0].id);
+  }
 };


### PR DESCRIPTION
📌 Description
- 메인 페이지에서 플랜 타이틀을 프리페치하고 0번째 요소의 id로 setCurrentPlanId를 해주었습니다. 
  - 로그인하면 메인페이지로 리다이렉트되는데 5분 내로 플랜페이지를 클릭하기 때문에 메인에서 미리 planId를 변경해 놓으면 로딩 시간이 줄어든다고 생각했습니다. 
-  authenticate 함수가 컴포넌트가 마운트 될 때마다 실행되고 있던 버그를 수정했습니다. 
- 태스크 드래그앤드롭이 ui에 반영되지 않던 버그를 해결했습니다. 

⚠️ 주의사항
- 이전 태스크 수정 모달이 plan에서 가져온 태스크를 보여주고 있어서 태스크를 수정할 때 description 반영이 안 된 거더라구요.
  - 수정중입니다.

close #138